### PR TITLE
fixed configure infinite loop when lua was missing from PATH

### DIFF
--- a/configure
+++ b/configure
@@ -2075,7 +2075,10 @@ else
 $as_echo "no" >&6; }
 fi
 
-
+if test x$luaprog = "x"; then
+  echo The program "lua" must be in your path
+  exit
+fi
 
 oldprog=$luaprog
 while test -L $luaprog; do
@@ -2093,11 +2096,6 @@ while test -L $luaprog; do
   fi
   oldprog=$luaprog
 done
-
-if test x$luaprog = "x"; then
-  echo The program "lua" must be in your path
-  exit
-fi
 
 echo -n "Checking for valid Lua version"
 


### PR DESCRIPTION
Moved lua-in-PATH check in the configure script to trigger before resolving symlink, before it would loop infinitely with missing operand to readlink etc. if lua was missing from PATH

```
.....
checking for sha1sum... /usr/bin/sha1sum
checking for more... /bin/more
checking for lua... no
readlink: missing operand
Try `readlink --help' for more information.
./configure: line 2086: test: !=: unary operator expected
readlink: missing operand
Try `readlink --help' for more information.
./configure: line 2086: test: !=: unary operator expected
readlink: missing operand
Try `readlink --help' for more information.
./configure: line 2086: test: !=: unary operator expected
readlink: missing operand
Try `readlink --help' for more information.
./configure: line 2086: test: !=: unary operator expected
....
....
```
