### PR TITLE
Fix cache generation when the whatis field contains quotes.

### DIFF
--- a/src/MC_Spider.lua
+++ b/src/MC_Spider.lua
@@ -162,7 +162,7 @@ function M.whatis(self,s)
    if (moduleT[path].whatis == nil) then
       moduleT[path].whatis ={}
    end
-   moduleT[path].whatis[#moduleT[path].whatis+1] = s
+   moduleT[path].whatis[#moduleT[path].whatis+1] = string.gsub(s, '"', '\\"')
    dbg.fini()
    return true
 end


### PR DESCRIPTION
Dear Dr. McLay,

Some modules (currently built through EasyBuild) may contain quotes in the whatis, e.g.:

module-whatis {Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases
 for RNA structure and sequence similarities. - Homepage: http://infernal.janelia.org/}

in the TCL/C Environment Modules file.
With the latest git version, Lmod crashes when trying to read the .cache/moduleT.lua cache file due to the unescaped quotes:

```
  whatis = {
    "Infernal ("INFERence of RNA ALignment") is for searching DNA sequence databases for RNA structure and sequence similarities. - Homepage: http://infernal.janelia.org/",
  }, 
```

This patch simply replaces all whatis field quote occurences by an escaped version.

Best regards,
Valentin Plugaru
Collaborator at the HPC Area, Computer Science and Communications Research Unit,
University of Luxembourg
