### PR TITLE
Bugfix for lua 5.3, possibly not backwards compatible

### DIFF
--- a/src/Var.lua
+++ b/src/Var.lua
@@ -97,8 +97,7 @@ local concatTbl     = table.concat
 local getenv        = os.getenv
 local min           = math.min
 local max           = math.max
-local pow           = math.pow
-local log10         = math.log10
+local log           = math.log
 local huge          = math.huge
 local posix         = require("posix")
 local setenv_posix  = posix.setenv
@@ -563,7 +562,7 @@ function M.expand(self)
    local factor  = 1
    local prT     = {}
    local maxV    = max(abs(self.imin), self.imax) + 1
-   local factor  = math.pow(10,ceil(log10(maxV)+1))
+   local factor  = 10^ceil(log(maxV,10)+1)
    local resultA = {}
    local tbl     = self.tbl
 


### PR DESCRIPTION
- math.pow has been deprecated (a^b is replaces)
  Hence it has been removed and replaced.

- log10 does not exist anymore, instead an optional
  argument to log denotes the base:
   log10(x) = log(x,10)

I am not too sure about how to make it backward compatible as I am not that experienced in
lua.
This bugfix works using lua 5.3.
Please advice how to make it backwards compatible.