### PR TITLE
Removing ".." and "." from a path.

### DIFF
--- a/tools/fileOps.lua
+++ b/tools/fileOps.lua
@@ -326,5 +326,16 @@ function path_regularize(value)
    if (value == '') then
       value = ' '
    end
-   return value
+   local t = {}
+   for dir in value:split("/") do
+      if (dir:sub(1,2) == ".." and dir:len() == 2) then
+         table.remove(t)
+      elseif (dir:sub(1,1) == "." and dir:len() == 1) then
+         -- no op
+      else
+         t[#t+1] = dir
+      end
+   end
+   local s = concatTbl(t,"/")
+   return s
 end


### PR DESCRIPTION
Tokenize the path within path_regularize() and remove any
parent directory ("..") and current directory (".") entries.
We also make sure the length of the path component is exactly
2 or 1 (in these cases). So as not to cause an error when reading
rc files.

At least until the posix library provides access to realpath().