### PR TITLE
Adding a active status.

### DIFF
--- a/init/lmodrc.lua
+++ b/init/lmodrc.lua
@@ -25,4 +25,10 @@ propT = {
          ["gpu:mic:offload"] = { short = "(@)",  long = "(g,m,o)", color = "red" , doc = "built natively for MIC and GPU and offload to the MIC",},
       },
    },
+   status = {
+      validT = { active = 1, },
+      displayT = {
+         active        = { short = "(A)",  long = "(A)",     color = "yellow", doc = "Active", },
+      },
+   },
 }

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -910,10 +910,14 @@ local function availEntry(defaultOnly, terse, label, szA, searchA, sn, name,
       local propT = {}
       local sn    = mname:sn()
       local entry = dbT[sn]
+      local am_active = mt.have(mt,sn,"active")
       if (entry) then
          dbg.print{"Found dbT[sn]\n"}
          if (entry[f]) then
             propT =  entry[f].propT or {}
+         end
+         if (am_active) then
+            propT["status"] = {active = 1}
          end
       else
          dbg.print{"Did not find dbT[sn]\n"}


### PR DESCRIPTION
When a user looks up what modules are available, the currently
loaded active modules will have a "(A)" property next to them.