### PR TITLE
Ability to view active modules.

### DIFF
--- a/init/lmodrc.lua
+++ b/init/lmodrc.lua
@@ -25,4 +25,10 @@ propT = {
          ["gpu:mic:offload"] = { short = "(@)",  long = "(g,m,o)", color = "red" , doc = "built natively for MIC and GPU and offload to the MIC",},
       },
    },
+   status = {
+      validT = { active = 1, },
+      displayT = {
+         active        = { short = "(A)",  long = "(A)",     color = "yellow", doc = "Active", },
+      },
+   },
 }

--- a/src/MT.lua
+++ b/src/MT.lua
@@ -1351,8 +1351,9 @@ function M.list(self, kind, status)
             if (v.default ~= 1) then
                nameT = "fullName"
             end
-            local obj = {sn   = v.short,   full       = v.fullName,
-                         name = v[nameT], defaultFlg = v.default }
+            local obj = {sn   = v.short,   full      = v.fullName,
+                         name = v[nameT], defaultFlg = v.default,
+                         fn   = v.FN }
             a[icnt] = { v.loadOrder, v[nameT], obj }
          end
       end

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -910,10 +910,14 @@ local function availEntry(defaultOnly, terse, label, szA, searchA, sn, name,
       local propT = {}
       local sn    = mname:sn()
       local entry = dbT[sn]
+      local am_active = mt.have(mt,sn,"active")
       if (entry) then
          dbg.print{"Found dbT[sn]\n"}
          if (entry[f]) then
             propT =  entry[f].propT or {}
+         end
+         if (am_active) then
+            propT["status"] = {active = 1}
          end
       else
          dbg.print{"Did not find dbT[sn]\n"}

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -910,14 +910,16 @@ local function availEntry(defaultOnly, terse, label, szA, searchA, sn, name,
       local propT = {}
       local sn    = mname:sn()
       local entry = dbT[sn]
-      local am_active = mt.have(mt,sn,"active")
       if (entry) then
          dbg.print{"Found dbT[sn]\n"}
          if (entry[f]) then
             propT =  entry[f].propT or {}
          end
-         if (am_active) then
-            propT["status"] = {active = 1}
+         local activeA = mt:list("userName","active")
+         for i = 1,#activeA do
+            if ( activeA[i].fn == f) then
+               propT["status"] = {active = 1}
+            end
          end
       else
          dbg.print{"Did not find dbT[sn]\n"}


### PR DESCRIPTION
When a user looks at all available modules (`ml av`), they can now see which modules are
loaded and active.