### PR TITLE
Attempt to support --show-hidden in module spider

### DIFF
--- a/src/Spider.lua
+++ b/src/Spider.lua
@@ -826,6 +826,9 @@ function M._Level2(self, T, searchName, full, possibleA)
    local c  = {}
    local titleIdx = 0
 
+   local masterTbl = masterTbl()
+   local hidden    = not masterTbl.show_hidden
+
    local propDisplayT = getPropT()
 
    local term_width = TermWidth() - 4
@@ -903,13 +906,28 @@ function M._Level2(self, T, searchName, full, possibleA)
 
          for i = 1, #v.parent do
             local entry = v.parent[i]
+            local d = {}
+            local f = {}
             for s in entry:split(":") do
                if (s ~= "default") then
-                  b[#b+1] = s
-                  b[#b+1] = '  '
+                  for e in s:split("/") do
+                     f[#f+1] = e
+                  end
+                  if (hidden and f[#f] ~= ".") then
+                     d = {}
+                     break
+                  end
+                  d[#d+1] = s
+                  d[#d+1] = '  '
                end
             end
-            b[#b] = "\n      "
+            if (#d > 0) then
+               for k in pairs(d) do
+                  b[#b+1] = k
+               end
+               d = {}
+               b[#b] = "\n      "
+            end
          end
          if (#b > 0) then
             b[#b] = "\n" -- Remove final comma add newline instead


### PR DESCRIPTION
I made an effort at this Robert but I couldn't get it to work properly. I was able to stop it showing the hidden options but not support `--show-hidden`, I probably missed how to bring that in properly. Also the output is not pretty if the only alternative options to spider involved hidden paths, the text regarding possible alternatives is still there even though they all get wiped out. To be honest I don't think this is the right place to even do this, it should probably happen before the options are added to `T` in the first place but I couldn't figure out where to target.
