### PR TITLE
Also escape $ in shell variables

### DIFF
--- a/shells/Bash.lua
+++ b/shells/Bash.lua
@@ -86,7 +86,7 @@ end
 
 function Bash.expandVar(self, k, v, vType)
    local lineA       = {}
-   v                 = tostring(v):doubleQuoteString()
+   v                 = tostring(v):doubleQuoteString():dollarSymbolEscaped()
    lineA[#lineA + 1] = k
    lineA[#lineA + 1] = "="
    lineA[#lineA + 1] = v

--- a/shells/Csh.lua
+++ b/shells/Csh.lua
@@ -82,7 +82,7 @@ function Csh.expandVar(self, k, v, vType)
    local middle      = ' '
    v                 = tostring(v)
    v                 = v:gsub("!","\\!")
-   v                 = v:doubleQuoteString()
+   v                 = v:doubleQuoteString():dollarSymbolEscaped()
    if (vType == "local_var") then
       lineA[#lineA + 1] = "set "
       middle            = "="

--- a/shells/Fish.lua
+++ b/shells/Fish.lua
@@ -86,7 +86,7 @@ end
 
 function Fish.expandVar(self, k, v, vType)
    local lineA       = {}
-   v                 = v:doubleQuoteString()
+   v                 = v:doubleQuoteString():dollarSymbolEscaped()
    if (vType == "path") then
       v = v:gsub(":",'" "')
    end

--- a/tools/string_utils.lua
+++ b/tools/string_utils.lua
@@ -107,6 +107,16 @@ function string.atSymbolEscaped(self)
    return self
 end
 
+--------------------------------------------------------------------------
+-- Escape $ character in input string.
+-- @param  self Input string.
+-- @return   An escaped $ in output.
+function string.dollarSymbolEscaped(self)
+   if (self == nil) then return self end
+   self = self:gsub('%$', '\\$')
+   return self
+end
+
 isLua51 = _VERSION:match('5%.1$')
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
I've been playing around with trying to manipulate a user's prompt when loading a modulefile. However, we have a tricky prompt that uses the __git_ps1 function to show the git branch in the prompt:
~~~~~
export PS1='[\u@\h \W$(__git_ps1 " (%s)")]\$ '
~~~~~
If we do a pushenv('PS1',..) in a modulefile, on unload we get:
~~~~~
bash: command substitution: line -48: syntax error near unexpected token `('
bash: command substitution: line -48: `__git_ps1 \" (%s)\")]\\$ "'
~~~~~
according to set -x, lmod is emitting:
~~~~~
'PS1="[\\u@\\h' '\\W$(__git_ps1' '\"' '(%s)\")]\\$' '";' export 'PS1;'
~~~~~
which just doesn't work. module --debug shows:
~~~~~
pushenv(PS1, (conda/prompt)nil){
MasterControl:popenv("PS1", "(conda/prompt)nil"){
stackName: __LMOD_STACK_PS1 pop()
Var:prt((1) Var:pop()){
name: "__LMOD_STACK_PS1"
imin: "1"
imax: "2"
value: "KGNvbmRhL3Byb21wdCluaWw=:W1x1QFxoIFxXJChfX2dpdF9wczEgIiAoJXMpIildXCQg"
"KGNvbmRhL3Byb21wdCluaWw=": {1, 0}
"W1x1QFxoIFxXJChfX2dpdF9wczEgIiAoJXMpIildXCQg": {2, 0}

} Var:prt
v: 1, imin: 1, min2: inf
v: 2, imin: 1, min2: inf
imin: 1, min2: 2
Var:prt((2) Var:pop()){
name: "__LMOD_STACK_PS1"
imin: "2"
imax: "2"
value: "KGNvbmRhL3Byb21wdCluaWw=:W1x1QFxoIFxXJChfX2dpdF9wczEgIiAoJXMpIildXCQg"
"W1x1QFxoIFxXJChfX2dpdF9wczEgIiAoJXMpIildXCQg": {2, 0}

} Var:prt
v: [\u@\h \W$(__git_ps1 " (%s)")]\$
} MasterControl:popenv

BaseShell:expand(tbl){
...
PS1="[\\u@\\h \\W$(__git_ps1 \" (%s)\")]\\$ ";
~~~~~
This is with Lmod 6.0.10.

Looks like it is using the lua %q format option to format the string, but this isn't working in this case.

Looks like %q is not escaping $ which needs to be done. This works:
~~~~~
PS1="[\\u@\\h \\W\$(__git_ps1 \" (%s)\")]\\\$ ";
~~~~~
So this PR adds that quoting.  This also allows setenv('VAR','a$b') to work.
