### PR TITLE
Workaround for metamodules picking up TCL over Lua modulefiles

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -936,7 +936,12 @@ function walk_directory_for_mf(mpath, path, prefix, dirA, mnameT)
    -- Copy files into mnameT.
    local ignoreT   = ignoreFileT()
 
+   local filenames = {}
    for file in lfs.dir(path) do
+     table.insert(filenames, file)
+   end
+   table.sort(filenames)
+   for i, file in pairs(filenames) do
       local idx       = defaultFnT[file] or defaultIdx
       if (idx < defaultIdx) then
          defaultIdx = idx


### PR DESCRIPTION
Hi Robert,

we ran into a strange bug, which was very painful to reproduce, when migrating from Tmod to Lmod.
It would manifest itself, by Lmod using the TCL modulefile, even though a Lua modulefile was available (which lead to problems down the road, because other modules depended on environment variables set in these). We had to identical copies of our module tree and this behavior occurred in one, but not the other. Lots of head scratching was the result. @andreaskarner and me did some Friday evening debugging came to the following conclusion (our best guess):

When using metamodules (I guess that's the nomenclature for modules without a version) it is possible that TCL modules get used over Lua, when a file listing done in walk_directory_for_mf() returns the Lua module first and after that the TCL module.
This is the listing that lfs.dir(path) returns for a directory consisting of only metamodules on our system:

        file: minimal
        file: use.own
        file: pythonlib
        file: dot.lua
        file: modules.lua
        file: aliases
        file: lsb
        file: lsb.lua
        file: impimba-1
        file: term.lua
        file: minimal.lua
        file: admin-tools
        file: perl5lib.lua
        file: aliases.lua
        file: build-tools
        file: impimba-1.lua
        file: modules
        file: pythonlib.lua
        file: term
        file: build-tools.lua
        file: admin-tools.lua
        file: perl5lib
        file: use.own.lua
        file: dot

We saw Lmod taking TCL over Lua for the modules: "modules", "term", "perl5lib" and "dot".
Albeit not being very elegant: sorting the file listing before operating on it solved this problem and we are (finally) running Lmod on our machine now (opt-in, but if you ask me that counts).

I'd appreciate your opinion on this PR - I hope we didn't break anything.

Best regards,
Georg

//cc @pforai 

