### PR TITLE
setenv setting environment variable to 'nil'

### DIFF
--- a/src/MasterControl.lua
+++ b/src/MasterControl.lua
@@ -505,7 +505,11 @@ function M.setenv(self, name, value, respect)
    if (varTbl[name] == nil) then
       varTbl[name] = Var:new(name)
    end
-   varTbl[name]:set(tostring(value))
+   if (value ~= nil) then
+     varTbl[name]:set(tostring(value))
+   else
+     varTbl[name]:set('')
+   end
    dbg.fini("MasterControl:setenv")
 end
 


### PR DESCRIPTION
Hi Robert,

when migrating from Tmod to Lmod we ran into this problem:
A TCL module contains the following line:

        setenv  RUBYOPT         ""

which gets converted by tcl2lua to:

        setenv("RUBYOPT")

The resulting environment variable has the value "nil", instead of "".

We fixed the issue by checking for nil values in the setenv function of MasterControl - that seemed to fix it. Does this seem like a good way to resolve this?

Best regards,
Georg

//cc @andreaskarner @pforai

