### PR TITLE
Add LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP ENV

### DIFF
--- a/src/Master.lua
+++ b/src/Master.lua
@@ -437,6 +437,19 @@ function M.load(mA)
                       "same name autoswapping."
             )
          end
+	 if (LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP == "yes") then
+		if (mt:fullName(sn) ~= t.modFullName) then
+		LmodError("Your site prevents the automatic swapping of modules with same name and different versions",
+		      "You must explicitly unload the loaded version of \"",sn,"\" before",
+		      "you can load the new one. Use swap (or an unload followed by a load)",
+		      "to do this:\n\n",
+		      "   $ module swap ",sn," ",moduleName,"\n\n",
+		      "Alternatively, you can set the environment variable",
+		      "LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP to \"no\" to re-enable",
+			      "same name autoswapping."
+		  )
+		end
+	 end
 
          local mcp_old = mcp
          mcp           = MCP

--- a/src/myGlobals.lua
+++ b/src/myGlobals.lua
@@ -153,6 +153,13 @@ LMOD_TMOD_PATH_RULE = initialize("LMOD_TMOD_PATH_RULE",
 LMOD_DISABLE_SAME_NAME_AUTOSWAP = initialize("LMOD_DISABLE_SAME_NAME_AUTOSWAP",
                                              "@disable_name_autoswap@")
 
+------------------------------------------------------------------------
+-- LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP: This env. var requires users to swap
+--                  out rather than using the one name rule. 
+------------------------------------------------------------------------
+
+LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP = initialize("LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP",
+                                             "no")
 --------------------------------------------------------------------------
 -- When restoring, use specified version instead of following the default
 --------------------------------------------------------------------------


### PR DESCRIPTION
LMOD_DISABLE_SAME_NAME_AUTOSWAP is too restrictive and too noisy. It generates errors for already loaded modules, where the ENV is identical.

LMOD_DISABLE_SAME_NAME_AND_DIFFERENT_VERSION_AUTOSWAP is only warning, then the version is different. This is very useful for long dependency chains, when more than one java version is used, or for python developers using more than one python version.