### PR TITLE
Set $LMOD_REVERSEMAPT_DIR after $LMOD_CACHE_DIR

### DIFF
--- a/src/update_lmod_system_cache_files.in
+++ b/src/update_lmod_system_cache_files.in
@@ -320,9 +320,6 @@ update_cache() {
 #########################################################################
 
 parse_cmdline $@
-if [ -z "$LMOD_REVERSEMAPT_DIR" ]; then
-  LMOD_REVERSEMAPT_DIR="$LMOD_CACHE_DIR/../reverseMapD"
-fi
 
 # put defaults in place for parameters that were not set
 set_defaults
@@ -330,10 +327,13 @@ set_defaults
 # check parameters (make sure they are defined)
 check_parameters
 
+if [ -z "$LMOD_REVERSEMAPT_DIR" ]; then
+  LMOD_REVERSEMAPT_DIR="$LMOD_CACHE_DIR/../reverseMapD"
+fi
+
 if [ -f ${LMOD_CACHE_TIMESTAMP_FILE}.new ]; then
    exit 0
 fi
-
 
 # create new timestamp file
 # timestamp file marks time of last change to the system, and *must* be older than the Lmod cache


### PR DESCRIPTION
In the cache update script:
As the default value of $LMOD_REVERSEMAPT_DIR, uses $LMOD_CACHE_DIR, it
should only be set after the defaults are set and checked.