### PR TITLE
Regularizing to z99 from z00 naming of /etc/profile.d files

### DIFF
--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -150,14 +150,18 @@ to get Lmod installed quickly by using the defaults:
   the spider caching system.  This will greatly speed up ``module
   avail`` and ``module spider``
 
-To install Lmod, you'll want to carefully read the following.  If you
-want Lmod version X.Y installed in ``/opt/apps/lmod/X.Y``, just do::
+If you want Lmod version X.Y installed in ``/opt/apps/lmod/X.Y``, use
+the following form of ``configure``::
 
     $ ./configure --prefix=/opt/apps
     $ make install
 
-The ``make install`` will install Lmod in ``/opt/apps/lmod/x.y.z``
-and create a link to ``/opt/apps/lmod/lmod``.
+Take special note!  The ``make install`` will create the ``lmod``
+directory *and* the ``lmod/X.Y`` under your prefix, and it will then
+create a link to ``/opt/apps/lmod/lmod``.  The symbolic link is
+created to ease upgrades to Lmod itself, as numbered versions can
+be installed side-by-side, testing can be done on the new version,
+and when all is ready, only the symbolic link needs changing.
 
 Sites can use::
 
@@ -166,31 +170,41 @@ Sites can use::
 which does everything but create the symbolic link.
 
 
-In the setup directory, there are ``profile.in`` and ``cshrc.in``
+In the ``init`` directory of the source code, there are ``profile.in`` and ``cshrc.in``
 templates. During the installation phase, the path to lua is added and
-profile and cshrc are written to the ``/opt/apps/lmod/lmod/init``
-directory. These files assume that your modulefiles are going to be
+``profile`` and ``cshrc`` are written to the ``/opt/apps/lmod/lmod/init``
+directory. These files were created assuming that your modulefiles are going to be
 located in ``/opt/apps/modulefiles/$LMOD_sys`` and
 ``/opt/apps/modulefiles/Core``, where ``$LMOD_sys`` is what the
-command "``uname``" reports, (i.e. Linux, Darwin). The layout of
-modulefiles is discussed later. Obviously you will need to match
-``MODULEPATH`` variable to where you have your modulefiles located.
+command "``uname``" reports, (e.g., Linux, Darwin). The layout of
+modulefiles is discussed later.
 
 .. note ::
-   Obviously you will want to modify the profile.in and cshrc.in files to suit
-   your system.
+   You should modify the ``profile.in`` and ``cshrc.in`` files to suit
+   your system if you choose to have a different location for your modulefiles.
+   The ``MODULEPATH`` variable must also match your system's modulefiles location.
 
 
 
-The profile file is Lmod initialization script for the bash, and zsh
-shells and cshrc file is for tcsh and csh shells. Please copy or link
-the profile and cshrc files to ``/etc/profile.d`` ::
+The ``profile`` file is Lmod initialization script for the bash, and zsh
+shells and ``cshrc`` file is for tcsh and csh shells.  Many sites find using
+the ``/etc/profiles.d`` directory, in which setup files to be sourced by users'
+shells at login are placed, to be a convenient way of insuring that Lmod is
+properly set up for all users.  When ``profiles.d`` is activated, the system
+login scripts will source, in glob order, the files that pertain to the current
+shell. See the next section for more details.
 
-    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z99_lmod.sh
-    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z99_lmod.csh
+It is important the the Lmod setup scripts are sourced late in the initialization
+process to insure that any existing modules setup has occurred and the Lmod will be
+last.  However, you probably want to leave some room at the end of the list of 
+files in ``/etc/profile.d``, so we pick a name that is likely to be at the end but
+still leave room for any really latecomers. ::
+
+    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z88_lmod.sh
+    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z88_lmod.csh
 
 To test the setup, you just need to login as a user. The module
-command should be set and MODULEPATH should be defined. Bash or Zsh
+command should be set and ``MODULEPATH`` should be defined. Bash or Zsh
 users should see something like::
 
      $ type module
@@ -205,7 +219,7 @@ users should see something like::
      $ echo $MODULEPATH
      /opt/apps/modulefiles/Linux:/opt/apps/modulefiles/Core
 
-Similar for csh users::
+Similarly, for csh users::
 
     % which module
     module: alias to eval `/opt/apps/lmod/lmod/libexec/lmod tcsh !*`

--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -186,8 +186,8 @@ The profile file is Lmod initialization script for the bash, and zsh
 shells and cshrc file is for tcsh and csh shells. Please copy or link
 the profile and cshrc files to ``/etc/profile.d`` ::
 
-    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z00_lmod.sh
-    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z00_lmod.csh
+    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z99_lmod.sh
+    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z99_lmod.csh
 
 To test the setup, you just need to login as a user. The module
 command should be set and MODULEPATH should be defined. Bash or Zsh

--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -141,7 +141,7 @@ Installing Lmod
 
 Lmod has a large number of configuration options.  They are discussed
 in the Configuring Lmod Guide.  This section is here will describe how
-to get Lmod installed quickly by using the defaults:
+to get Lmod installed quickly by using the defaults.
 
 
 .. note ::
@@ -153,17 +153,20 @@ to get Lmod installed quickly by using the defaults:
 If you want Lmod version X.Y installed in ``/opt/apps/lmod/X.Y``, use
 the following form of ``configure``::
 
+Lmod uses two-tiered installation tree, and automatically creates a version
+directory for itself.  So, for example, if the installation prefix is set
+to ``/opt/apps``, and the current version is ``X.Y.Z``, installation will
+create ``/opt/apps/lmod`` and ``/opt/apps/lmod/X.Y.Z``.
+
     $ ./configure --prefix=/opt/apps
     $ make install
 
-Take special note!  The ``make install`` will create the ``lmod``
-directory *and* the ``lmod/X.Y`` under your prefix, and it will then
-create a link to ``/opt/apps/lmod/lmod``.  The symbolic link is
-created to ease upgrades to Lmod itself, as numbered versions can
-be installed side-by-side, testing can be done on the new version,
-and when all is ready, only the symbolic link needs changing.
+The installation will also create a link to ``/opt/apps/lmod/lmod``.  The
+symbolic link is created to ease upgrades to Lmod itself, as numbered
+versions can be installed side-by-side, testing can be done on the new
+version, and when all is ready, only the symbolic link needs changing.
 
-Sites can use::
+To create such a testing installation, you can use::
 
     $ make pre-install
 
@@ -194,14 +197,15 @@ properly set up for all users.  When ``profiles.d`` is activated, the system
 login scripts will source, in glob order, the files that pertain to the current
 shell. See the next section for more details.
 
-It is important the the Lmod setup scripts are sourced late in the initialization
-process to insure that any existing modules setup has occurred and the Lmod will be
-last.  However, you probably want to leave some room at the end of the list of 
-files in ``/etc/profile.d``, so we pick a name that is likely to be at the end but
-still leave room for any really latecomers. ::
+It is important that the Lmod setup scripts are sourced late in the
+initialization process to insure that any existing modules setup has
+occurred.  However, you probably want to leave some room at the end of the
+list of files in ``/etc/profile.d``, so we pick a name that is likely to be
+at the end but still leave room for any initialization scripts that should come
+later. ::
 
-    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z88_lmod.sh
-    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z88_lmod.csh
+    $ ln -s /opt/apps/lmod/lmod/init/profile /etc/profile.d/z00_lmod.sh
+    $ ln -s /opt/apps/lmod/lmod/init/cshrc   /etc/profile.d/z00_lmod.csh
 
 To test the setup, you just need to login as a user. The module
 command should be set and ``MODULEPATH`` should be defined. Bash or Zsh

--- a/docs/source/045_transition.rst
+++ b/docs/source/045_transition.rst
@@ -182,7 +182,7 @@ to use Lmod, I recommend the following strategy for staff and
 friendly/power users for testing:
 
 #. Install Lua and Lmod in system locations.
-#. Install */etc/profile.d/z00_lmod.sh* to redefine the module command
+#. Install */etc/profile.d/z99_lmod.sh* to redefine the module command
 #. Load system default modules (if any) after previous step
 #. Only user who have a file named *~/.lmod* use Lmod.
 #. At TACC, we did this for 6 months.
@@ -196,7 +196,7 @@ How to Deploy Lmod
 Once Staff testing is complete and you are ready to deploy Lmod to
 your users it is quite easy to switch to an opt-out strategy:
 
-#. Change */etc/profile.d/z00_lmod.sh* so that everyone is using Lmod
+#. Change */etc/profile.d/z99_lmod.sh* so that everyone is using Lmod
 #. If a user has a ~/.no.lmod then they continue to use your original
    module system.
 #. At TACC we did this for another 6 months.

--- a/docs/source/045_transition.rst
+++ b/docs/source/045_transition.rst
@@ -182,7 +182,7 @@ to use Lmod, I recommend the following strategy for staff and
 friendly/power users for testing:
 
 #. Install Lua and Lmod in system locations.
-#. Install */etc/profile.d/z99_lmod.sh* to redefine the module command
+#. Install */etc/profile.d/z00_lmod.sh* to redefine the module command
 #. Load system default modules (if any) after previous step
 #. Only user who have a file named *~/.lmod* use Lmod.
 #. At TACC, we did this for 6 months.
@@ -196,7 +196,7 @@ How to Deploy Lmod
 Once Staff testing is complete and you are ready to deploy Lmod to
 your users it is quite easy to switch to an opt-out strategy:
 
-#. Change */etc/profile.d/z99_lmod.sh* so that everyone is using Lmod
+#. Change */etc/profile.d/z00_lmod.sh* so that everyone is using Lmod
 #. If a user has a ~/.no.lmod then they continue to use your original
    module system.
 #. At TACC we did this for another 6 months.

--- a/docs/source/070_standard_modules.rst
+++ b/docs/source/070_standard_modules.rst
@@ -12,7 +12,7 @@ login. In ``StdEnv.lua`` is something like: ::
     load("name1","name2","name3")
 
 Using the /etc/profile.d directory system described earlier create a
-file called ``z99_StdEnv.sh`` ::
+file called ``z00_StdEnv.sh`` ::
 
     if [ -z "$__Init_Default_Modules" -o -z "$LD_LIBRARY_PATH" ]; then
        export __Init_Default_Modules=1;
@@ -22,7 +22,7 @@ file called ``z99_StdEnv.sh`` ::
        module refresh
     fi
 
-Similar for z99_StdEnv.csh::
+Similar for z00_StdEnv.csh::
 
     if ( ! $?__Init_Default_Modules || ! $?LD_LIBRARY_PATH )  then
       setenv LMOD_SYSTEM_DEFAULT_MODULES "StdEnv"
@@ -32,7 +32,7 @@ Similar for z99_StdEnv.csh::
       module refresh
     endif
 
-The z99_Stdenv.* names are chosen because the files in /etc/profile.d
+The z00_Stdenv.* names are chosen because the files in /etc/profile.d
 are sourced in alphabetical order. These names guarantee they will run
 after the module command is defined.
 


### PR DESCRIPTION
Earlier sections used /etc/profile.d/z00_lmod.[sh|csh] and said it was to make them last in the source list; section 4.5 has z99, which would be later.  Changed the earlier references to match z99.