### PR TITLE
Add hook for restore

### DIFF
--- a/src/Hook.lua
+++ b/src/Hook.lua
@@ -60,6 +60,7 @@ local validT =
                                -- to moduleT.lua to make it safe on
                                -- shared filesystems.
       avail          = false,  -- Map directory names to labels
+      restore        = false,  -- This hook is run after restore operation
 }
 
 --------------------------------------------------------------------------

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -592,6 +592,8 @@ function Restore(collection)
       end
    end
 
+   hook.apply("restore", {collection=collection, name=myName, fn=path})
+
    dbg.fini("Restore")
 end
 


### PR DESCRIPTION
The hook is run after the restore operation and has as argument a table
with the collection, the name of the collection and the path to the
collection file.


@rtmclay It's not very clear to me what the difference is between the `collection` and the `myName` of the collection in the restore function?