### PR TITLE
Let --terse respect LMOD_REDIRECT

### DIFF
--- a/src/Master.lua
+++ b/src/Master.lua
@@ -1153,10 +1153,19 @@ function M.avail(argA)
          local a     = {}
          availDir(defaultOnly, terse, searchA, mpath, locationT, availT[mpath], dbT, a, legendT)
          if (next(a)) then
-            io.stderr:write(mpath,":\n")
-            for i=1,#a do
-               io.stderr:write(a[i],"\n")
-            end
+             if (LMOD_REDIRECT == "no") then
+                 io.stderr:write(mpath,":\n")
+             else
+                 shell:echo(mpath)
+             end
+
+             for i=1,#a do
+                 if (LMOD_REDIRECT == "no") then
+                     io.stderr:write(a[i],"\n")
+                 else
+                     shell:echo(a[i])
+                 end
+             end
          end
       end
       dbg.fini("Master:avail")

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -127,7 +127,11 @@ function CollectionLst(collection)
    local shell     = Master:master().shell
    if (masterTbl.terse) then
       for i = 1,#a do
-         io.stderr:write(a[i],"\n")
+         if (LMOD_REDIRECT == "no") then
+             io.stderr:write(a[i],"\n")
+         else
+             shell:echo(a[i])
+         end
       end
    else
       if (#a < 1) then
@@ -259,7 +263,11 @@ function List(...)
          for j = 1, wanted.n do
             local p = wanted[j]
             if (full:find(p)) then
-               io.stderr:write(full,"\n")
+                if (LMOD_REDIRECT == "no") then
+                    io.stderr:write(full,"\n")
+                else
+                    shell:echo(full)
+                end
             end
          end
       end
@@ -684,7 +692,11 @@ function SaveList(...)
          if (i) then
             name = name:sub(j+2)
          end
-         io.stderr:write(name,"\n")
+         if (LMOD_REDIRECT == "no") then
+             io.stderr:write(name,"\n")
+         else
+             shell:echo(name)
+         end
       end
       return
    end
@@ -775,7 +787,11 @@ function SpiderCmd(...)
    end
 
    if (masterTbl.terse) then
-      io.stderr:write(s,"\n")
+     if (LMOD_REDIRECT == "no") then
+         io.stderr:write(s,"\n")
+     else
+         shell:echo(s)
+     end
    else
       local a = {}
       a[#a+1] = s


### PR DESCRIPTION
Currently, --terse always dumps to stderr. Giving:
`ml --redirect av` dumps to stdout while `ml --redirect --terse av` dumps to stderr.

@rtmclay Thoughts? It's probably cleaner to put this in a wrapper instead of copy paste the same if over and over again?