### PR TITLE
Put the reverse map under the cache dir, not next to it.

### DIFF
--- a/src/update_lmod_system_cache_files.in
+++ b/src/update_lmod_system_cache_files.in
@@ -334,7 +334,7 @@ set_defaults
 check_parameters
 
 if [ -z "$LMOD_REVERSEMAPT_DIR" ]; then
-  LMOD_REVERSEMAPT_DIR="$LMOD_CACHE_DIR/../reverseMapD"
+  LMOD_REVERSEMAPT_DIR="$LMOD_CACHE_DIR/reverseMapD"
 fi
 
 # create new timestamp file


### PR DESCRIPTION
It's not very practical that the reverse map gets put in another directory. I think it's best if we specify one directory for the Lmod cache and everything gets put below that?
