### PR TITLE
Let module list obey LMOD_REDIRECT

### DIFF
--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -226,7 +226,7 @@ function List(...)
    local mt = MT:mt()
    local totalA = mt:list("userName","any")
    if (#totalA < 1) then
-      LmodMessage("No modules loaded\n")
+      shell:echo("No modules loaded\n")
       dbg.fini("List")
       return
    end


### PR DESCRIPTION
Current, when you do module list:
- If no modules are loaded -> stderr
- If modules are loaded -> depends on LMOD_REDIRECT

This commit makes list always obey LMOD_REDIRECT