### PR TITLE
Fixed bug where .version file will be treated as modulefile if versionFile() returns a version that doesn't exist

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -959,8 +959,12 @@ function walk_directory_for_mf(mpath, path, prefix, dirA, mnameT)
    for file in lfs.dir(path) do
       local idx       = defaultFnT[file] or defaultIdx
       if (idx < defaultIdx) then
+         -- If .version file is found:
          defaultIdx = idx
-         defaultFn  = pathJoin(path,file)
+         local versionFilePath = pathJoin(path,versionFile(file, prefix, pathJoin(path,file),false))
+         if (isFile(versionFilePath)) then
+           defaultFn  = pathJoin(path,file)
+         end
       else
          if (keepFile(file))then
             local f        = pathJoin(path,file)


### PR DESCRIPTION
Added check to walk_directory_for_mf() that ensures that the expected default version actually exists and that seemed to fix it.