### PR TITLE
also consider 'md5' as alternative to md5sum

### DIFF
--- a/configure
+++ b/configure
@@ -3430,7 +3430,7 @@ fi
 
 
 
-for ac_prog in sha1sum gsha1sum md5sum gmd5sum md5
+for ac_prog in sha1sum gsha1sum md5sum gmd5sum
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure
+++ b/configure
@@ -3430,7 +3430,7 @@ fi
 
 
 
-for ac_prog in sha1sum gsha1sum md5sum gmd5sum
+for ac_prog in sha1sum gsha1sum md5sum gmd5sum md5
 do
   # Extract the first word of "$ac_prog", so it can be a program name with args.
 set dummy $ac_prog; ac_word=$2

--- a/configure.ac
+++ b/configure.ac
@@ -352,7 +352,6 @@ AC_PATH_PROG(PATH_TO_GIT, git, "")
 AC_PATH_PROG(PATH_TO_PAGER,[less] [more], [more])
 
 AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum] [md5], UNKNOWN)
-echo "PATH_TO_HASHSUM: $PATH_TO_HASHSUM"
 if test "`basename $PATH_TO_HASHSUM`" = "md5" ; then
   PATH_TO_HASHSUM="$PATH_TO_HASHSUM -r"
 elif test "$PATH_TO_HASHSUM" = "UNKNOWN" ; then

--- a/configure.ac
+++ b/configure.ac
@@ -351,8 +351,11 @@ fi
 AC_PATH_PROG(PATH_TO_GIT, git, "")
 AC_PATH_PROG(PATH_TO_PAGER,[less] [more], [more])
 
-AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum], [md5], UNKNOWN)
-if test "$PATH_TO_HASHSUM" = "UNKNOWN" ; then
+AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum] [md5], UNKNOWN)
+echo "PATH_TO_HASHSUM: $PATH_TO_HASHSUM"
+if test "`basename $PATH_TO_HASHSUM`" = "md5" ; then
+  PATH_TO_HASHSUM="$PATH_TO_HASHSUM -r"
+elif test "$PATH_TO_HASHSUM" = "UNKNOWN" ; then
   echo
   echo "You must have either sha1sum or md5sum in your path. Quitting!"
   echo

--- a/configure.ac
+++ b/configure.ac
@@ -351,7 +351,7 @@ fi
 AC_PATH_PROG(PATH_TO_GIT, git, "")
 AC_PATH_PROG(PATH_TO_PAGER,[less] [more], [more])
 
-AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum], UNKNOWN)
+AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum], [md5], UNKNOWN)
 if test "$PATH_TO_HASHSUM" = "UNKNOWN" ; then
   echo
   echo "You must have either sha1sum or md5sum in your path. Quitting!"


### PR DESCRIPTION
By default, I don't have `sha1sum` or `md5sum` available on my OS X system (El Capitan, 10.11.5), but I do have `md5` available in `/sbin`...

@rtmclay I didn't regenerate `configure` from `configure.ac` properly here, but I'm not sure that matters at all for a change this trivial.