### PR TITLE
add Travis config for Lmod test suite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,7 +33,7 @@ script:
   - tm
 
 after_failure:
-  - for dir in $(find rt -type d -d 1); do
+  - for dir in $(find rt -depth 1 -type d); do
     echo ">>>> ${dir}/err.txt"; diff -u ${dir}/err.txt ${dir}/t1/*/err.txt;
     echo ">>>> ${dir}/out.txt"; diff -u ${dir}/out.txt ${dir}/t1/*/out.txt;
     done

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,13 @@ install:
 
 script:
   - which sha1sum
+  - /bin/tcsh --version
   - lua -e 'print(_VERSION)'
   - luarocks list
   - tm
+  - diff -u rt/csh_swap/err.txt rt/csh_swap/*/*/err.txt
+  - diff -u rt/delcatty/err.txt rt/delcatty/*/*/err.txt
+  - diff -u rt/end2end/err.txt rt/end2end/*/*/err.txt
+  - diff -u rt/errHandler/err.txt rt/errHandler/*/*/err.txt
+  - diff -u rt/hook/err.txt rt/hook/*/*/err.txt
+  - diff -u rt/modulerc/err.txt rt/modulerc/*/*/err.txt

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,8 +32,7 @@ script:
   - /bin/tcsh --version
   - lua -e 'print(_VERSION)'
   - luarocks list
-#  - tm
-  - tm -k delcatty
+  - LMOD_TERM_WIDTH=80 tm
 
 after_failure:
   - for dir in $(ls -pd rt/* | grep '/$'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,11 +2,9 @@ language: python
 sudo: false
 
 env:
-  - LMOD_TERM_WIDTH=80
-  matrix:
-    - LUA='lua=5.1'
-    - LUA='lua=5.2'
-    - LUA='lua=5.3'
+  - LUA='lua=5.1'
+  - LUA='lua=5.2'
+  - LUA='lua=5.3'
 
 addons:
   apt:
@@ -30,6 +28,8 @@ install:
   - luarocks install lua-term
 
 script:
+  # run Lmod test suite with Hermes
+  - export LMOD_TERM_WIDTH=80
   - tm
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,11 @@ env:
   - LUA="lua=5.2"
   - LUA="lua=5.3"
 
+addons:
+  apt:
+    packages:
+      - tcl8.5
+
 before_install:
   - cd $HOME
   - pip install hererocks
@@ -26,9 +31,9 @@ script:
   - lua -e 'print(_VERSION)'
   - luarocks list
   - tm
-  - diff -u rt/csh_swap/err.txt rt/csh_swap/*/*/err.txt
-  - diff -u rt/delcatty/err.txt rt/delcatty/*/*/err.txt
-  - diff -u rt/end2end/err.txt rt/end2end/*/*/err.txt
-  - diff -u rt/errHandler/err.txt rt/errHandler/*/*/err.txt
-  - diff -u rt/hook/err.txt rt/hook/*/*/err.txt
-  - diff -u rt/modulerc/err.txt rt/modulerc/*/*/err.txt
+
+after_failure:
+  - for dir in $(find rt -type d -d 1); do
+    echo ">>>> ${dir}/err.txt"; diff -u ${dir}/err.txt ${dir}/t1/*/err.txt;
+    echo ">>>> ${dir}/out.txt"; diff -u ${dir}/out.txt ${dir}/t1/*/out.txt;
+    done

--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,6 @@ install:
 
 script:
   # run Lmod test suite with Hermes
-  - export COLUMNS=80
   - tm
 
 after_failure:

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 addons:
   apt:
     packages:
+      - tcsh
       - tcl8.5
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ script:
   - tm
 
 after_failure:
-  - for dir in $(find rt -depth 1 -type d); do
+  - for dir in $(ls -pd rt/* | grep '/$'); do
     echo ">>>> ${dir}/err.txt"; diff -u ${dir}/err.txt ${dir}/t1/*/err.txt;
     echo ">>>> ${dir}/out.txt"; diff -u ${dir}/out.txt ${dir}/t1/*/out.txt;
     done

--- a/.travis.yml
+++ b/.travis.yml
@@ -30,13 +30,10 @@ install:
   - luarocks install lua-term
 
 script:
-  - which sha1sum
-  - /bin/tcsh --version
-  - lua -e 'print(_VERSION)'
-  - luarocks list
   - tm
 
 after_failure:
+  # diff stdout/stderr for all tests in case of failure
   - for dir in $(ls -pd rt/* | grep '/$'); do
     echo ">>>> ${dir}/err.txt"; diff -u ${dir}/err.txt ${dir}/t1/*/err.txt;
     echo ">>>> ${dir}/out.txt"; diff -u ${dir}/out.txt ${dir}/t1/*/out.txt;

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,9 +7,12 @@ env:
   - LUA="lua=5.3"
 
 before_install:
+  - cd $HOME
   - pip install hererocks
   - hererocks lua_install -r^ --$LUA
-  - export PATH="$PATH:$PWD/lua_install/bin"
+  - git clone https://github.com/rtmclay/Hermes.git
+  - export PATH="$PATH:$PWD/lua_install/bin:$HOME/Hermes/bin"
+  - cd -
 
 install:
   - luarocks install luaposix
@@ -18,5 +21,7 @@ install:
   - luarocks install lua-term
 
 script:
+  - which sha1sum
   - lua -e 'print(_VERSION)'
   - luarocks list
+  - tm

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,15 +2,16 @@ language: python
 sudo: false
 
 env:
-  - LUA="lua=5.1"
-  - LUA="lua=5.2"
-  - LUA="lua=5.3"
+  - LUA='lua=5.1'
+  - LUA='lua=5.2'
+  - LUA='lua=5.3'
 
 addons:
   apt:
     packages:
       - tcsh
       - tcl8.5
+      - util-linux  # for uuidgen
 
 before_install:
   - cd $HOME
@@ -31,7 +32,8 @@ script:
   - /bin/tcsh --version
   - lua -e 'print(_VERSION)'
   - luarocks list
-  - tm
+#  - tm
+  - tm -k delcatty
 
 after_failure:
   - for dir in $(ls -pd rt/* | grep '/$'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,7 @@ addons:
     packages:
       - tcsh
       - tcl8.5
-      - util-linux  # for uuidgen
+      - uuid  # for uuidgen
 
 before_install:
   - cd $HOME

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,22 @@
+language: python
+sudo: false
+
+env:
+  - LUA="lua=5.1"
+  - LUA="lua=5.2"
+  - LUA="lua=5.3"
+
+before_install:
+  - pip install hererocks
+  - hererocks lua_install -r^ --$LUA
+  - export PATH="$PATH:$PWD/lua_install/bin"
+
+install:
+  - luarocks install luaposix
+  - luarocks install luafileSystem
+  - luarocks install luajson
+  - luarocks install lua-term
+
+script:
+  - lua -e 'print(_VERSION)'
+  - luarocks list

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,11 @@ language: python
 sudo: false
 
 env:
-  - LUA='lua=5.1'
-  - LUA='lua=5.2'
-  - LUA='lua=5.3'
+  - LMOD_TERM_WIDTH=80
+  matrix:
+    - LUA='lua=5.1'
+    - LUA='lua=5.2'
+    - LUA='lua=5.3'
 
 addons:
   apt:
@@ -32,7 +34,7 @@ script:
   - /bin/tcsh --version
   - lua -e 'print(_VERSION)'
   - luarocks list
-  - LMOD_TERM_WIDTH=80 tm
+  - tm
 
 after_failure:
   - for dir in $(ls -pd rt/* | grep '/$'); do

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+# although Lmod is written in Lua, use Python environment
 language: python
 sudo: false
 
@@ -15,8 +16,10 @@ addons:
 
 before_install:
   - cd $HOME
+  # install Lua via hererocks
   - pip install hererocks
   - hererocks lua_install -r^ --$LUA
+  # install Hermes test tool
   - git clone https://github.com/rtmclay/Hermes.git
   - export PATH="$PATH:$PWD/lua_install/bin:$HOME/Hermes/bin"
   - cd -
@@ -29,7 +32,7 @@ install:
 
 script:
   # run Lmod test suite with Hermes
-  - export LMOD_TERM_WIDTH=80
+  - export COLUMNS=80
   - tm
 
 after_failure:

--- a/rt/common_funcs.sh
+++ b/rt/common_funcs.sh
@@ -179,6 +179,7 @@ initStdEnvVars()
   COUNT=0
   ORIG_HOME=`(cd $HOME; /bin/pwd)`
   HOME=`/bin/pwd`
+  export LMOD_TERM_WIDTH=80
 
   export PATH=$projectDir/src:$PATH_to_LUA:$PATH_to_TM:$PATH_to_SHA1:/usr/bin:/bin
 

--- a/rt/delcatty/delcatty.tdesc
+++ b/rt/delcatty/delcatty.tdesc
@@ -25,6 +25,7 @@ testdescript = {
      COUNT=0
      ORIG_HOME=`(cd $HOME; /bin/pwd)`
      HOME=`/bin/pwd`
+     export LMOD_TERM_WIDTH=500
 
 
      rm -fr _stderr.* _stdout.* err.* out.* .lmod.d

--- a/rt/delcatty/err.txt
+++ b/rt/delcatty/err.txt
@@ -23,8 +23,7 @@ step 5
 lua ProjectDIR/src/lmod.in.lua bash load Error
 ===========================
 Lmod has detected the following error: Unable to load module: Error
-     ProjectDIR/rt/delcatty/mf/Core/Error/1.0 : Non-zero status
-returned
+     ProjectDIR/rt/delcatty/mf/Core/Error/1.0 : Non-zero status returned
 While processing the following module(s):
     Module fullname  Module Filename
     Error/1.0        ProjectDIR/rt/delcatty/mf/Core/Error/1.0

--- a/rt/errHandler/err.txt
+++ b/rt/errHandler/err.txt
@@ -17,8 +17,7 @@ While processing the following module(s):
 step 3
 lua ProjectDIR/src/lmod.in.lua bash load bad_argument
 ===========================
-Lmod has detected the following error: Syntax error in file:
-ProjectDIR/rt/errHandler/mf/bad_argument/1.0.lua
+Lmod has detected the following error: Syntax error in file: ProjectDIR/rt/errHandler/mf/bad_argument/1.0.lua
  with command: help  One or more arguments are not strings
 While processing the following module(s):
     Module fullname   Module Filename

--- a/rt/errHandler/err.txt
+++ b/rt/errHandler/err.txt
@@ -9,8 +9,7 @@ step 2
 lua ProjectDIR/src/lmod.in.lua bash load bad_syntax
 ===========================
 Lmod has detected the following error: Unable to load module: bad_syntax
-     ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua : [string
-"setenv("BAD_SYNTAX","1.0")..."]:2: unexpected symbol near '#'
+     ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua : [string "setenv("BAD_SYNTAX","1.0")..."]:2: unexpected symbol near '#'
 While processing the following module(s):
     Module fullname  Module Filename
     bad_syntax/1.0   ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua

--- a/rt/errHandler/errHander.tdesc
+++ b/rt/errHandler/errHander.tdesc
@@ -19,6 +19,7 @@ testdescript = {
      unsetMT
      initStdEnvVars
      MODULEPATH=$(testDir)/mf;          export MODULEPATH
+     export LMOD_TERM_WIDTH=500
 
      rm -fr _stderr.* _stdout.* err.* out.* .lmod.d
 

--- a/rt/modulerc/err.txt
+++ b/rt/modulerc/err.txt
@@ -95,8 +95,7 @@ ProjectDIR/rt/modulerc/mf/Core
    D:  Default Module
    L:  Module is loaded
 Use "module spider" to find all possible modules.
-Use "module keyword key1 key2 ..." to search for all possible modules matching
-any of the "keys".
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
 ===========================
 step 17
 lua ProjectDIR/src/lmod.in.lua bash avail
@@ -112,8 +111,7 @@ ProjectDIR/rt/modulerc/mf/Core
    D:  Default Module
    L:  Module is loaded
 Use "module spider" to find all possible modules.
-Use "module keyword key1 key2 ..." to search for all possible modules matching
-any of the "keys".
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
 ===========================
 step 18
 lua ProjectDIR/src/lmod.in.lua bash avail
@@ -129,8 +127,7 @@ ProjectDIR/rt/modulerc/mf/Core
    D:  Default Module
    L:  Module is loaded
 Use "module spider" to find all possible modules.
-Use "module keyword key1 key2 ..." to search for all possible modules matching
-any of the "keys".
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
 ===========================
 step 19
 lua ProjectDIR/src/lmod.in.lua bash avail
@@ -146,12 +143,10 @@ ProjectDIR/rt/modulerc/mf/Core
    D:  Default Module
    L:  Module is loaded
 Use "module spider" to find all possible modules.
-Use "module keyword key1 key2 ..." to search for all possible modules matching
-any of the "keys".
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
 ===========================
 step 20
 lua ProjectDIR/src/lmod.in.lua bash load cluster
 ===========================
 The default cluster module cannot be determined. Please set $VSC_DEFAULT_CLUSTER_MODULE.
-Lmod has detected the following error: Unable to parse:
-ProjectDIR/rt/modulerc/mf2/Core/cluster/.modulerc  Aborting!
+Lmod has detected the following error: Unable to parse: ProjectDIR/rt/modulerc/mf2/Core/cluster/.modulerc  Aborting!

--- a/rt/modulerc/modulerc.tdesc
+++ b/rt/modulerc/modulerc.tdesc
@@ -31,6 +31,7 @@ testdescript = {
 
      export MODULEPATH_ROOT=$(testDir)/mf
      export MODULEPATH=$MODULEPATH_ROOT/Core
+     export LMOD_TERM_WIDTH=500
 
 
      runLmod --version               # 1


### PR DESCRIPTION
This is not ready yet, currently 5 tests are failing on Travis (cfr. https://travis-ci.org/boegel/Lmod/builds/136810652). Also, I may squash all commits here, it's a bit messy now.

```
diff     /home/travis/build/boegel/Lmod/rt/delcatty/t1/2016_06_10_21_06_32-Linux-x86_64-delcatty
diff     /home/travis/build/boegel/Lmod/rt/end2end/t1/2016_06_10_21_06_32-Linux-x86_64-end2end
diff     /home/travis/build/boegel/Lmod/rt/errHandler/t1/2016_06_10_21_06_32-Linux-x86_64-errHandler
diff     /home/travis/build/boegel/Lmod/rt/hook/t1/2016_06_10_21_06_32-Linux-x86_64-hook
diff     /home/travis/build/boegel/Lmod/rt/modulerc/t1/2016_06_10_21_06_32-Linux-x86_64-modulerc
```

My analysis:

* `delcatty`, `errHandler` and `modulerc` fails because of line wrapping; I tried to fix this by defining `$LMOD_TERM_WIDTH` and `$COLUMNS` to `80`, but it doesn't help

* `hook`: fails because `uuidgen` is missing; it seems like I would need to install the `uuid-runtime` package should be installed, but it is not whitelisted yet on Travis (see list @ https://github.com/travis-ci/apt-package-whitelist/blob/master/ubuntu-precise)

* `end2end` fails with `ProjectDIR/rt/common_funcs.sh: line 64: OutputDIR/lmod/lmod/libexec/lmod: No such file or directory`; no idea what may be the cause of this...

More detailed diffs for `err.txt` below (diff for `out.txt` is empty for each of these).

* `delcatty` (empty diff for `out.txt`):
```
>>>> rt/delcatty//err.txt
--- rt/delcatty//err.txt	2016-06-10 21:05:59.206541387 +0000
+++ rt/delcatty//t1/2016_06_10_21_06_32-Linux-x86_64-delcatty/err.txt	2016-06-10 21:07:36.785365249 +0000
@@ -2,7 +2,7 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua bash --version
 ===========================
-Modules based on Lua: Version 6.0.26  2016-01-29 11:03
+Modules based on Lua: Version 6.4.1  2016-06-04 08:48
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
@@ -23,8 +23,8 @@
 lua ProjectDIR/src/lmod.in.lua bash load Error
 ===========================
 Lmod has detected the following error: Unable to load module: Error
-     ProjectDIR/rt/delcatty/mf/Core/Error/1.0 : Non-zero status
-returned
+     ProjectDIR/rt/delcatty/mf/Core/Error/1.0 : Non-zero
+status returned
 While processing the following module(s):
     Module fullname  Module Filename
     Error/1.0        ProjectDIR/rt/delcatty/mf/Core/Error/1.0
```

* `end2end`
```
--- rt/end2end//err.txt	2016-06-10 21:05:59.210541338 +0000
+++ rt/end2end//t1/2016_06_10_21_06_32-Linux-x86_64-end2end/err.txt	2016-06-10 21:06:34.046121377 +0000
@@ -2,21 +2,20 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua bash --version
 ===========================
-Modules based on Lua: Version 6.0.19  2015-11-18 08:32
+Modules based on Lua: Version 6.4.1  2016-06-04 08:48
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
  OutputDIR/lmod/lmod/libexec/lmod --version
 ===========================
-Modules based on Lua: Version 6.0.19 (6.0.19-3-gff50a53) 2015-11-18 08:32
-    by Robert McLay mclay@tacc.utexas.edu
+ProjectDIR/rt/common_funcs.sh: line 64: OutputDIR/lmod/lmod/libexec/lmod: No such file or directory
 ===========================
 step 3
  OutputDIR/lmod/lmod/libexec/lmod load admin
 ===========================
+ProjectDIR/rt/common_funcs.sh: line 64: OutputDIR/lmod/lmod/libexec/lmod: No such file or directory
 ===========================
 step 4
  OutputDIR/lmod/lmod/libexec/lmod list
 ===========================
-Currently Loaded Modules:
-  1) admin/admin-1.0
+ProjectDIR/rt/common_funcs.sh: line 64: OutputDIR/lmod/lmod/libexec/lmod: No such file or directory
```

* `errHandler`
```
--- rt/errHandler//err.txt	2016-06-10 21:05:59.210541338 +0000
+++ rt/errHandler//t1/2016_06_10_21_06_32-Linux-x86_64-errHandler/err.txt	2016-06-10 21:07:17.777594298 +0000
@@ -2,15 +2,15 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua bash --version
 ===========================
-Modules based on Lua: Version 6.0.26  2016-01-29 11:03
+Modules based on Lua: Version 6.4.1  2016-06-04 08:48
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
 lua ProjectDIR/src/lmod.in.lua bash load bad_syntax
 ===========================
 Lmod has detected the following error: Unable to load module: bad_syntax
-     ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua : [string
-"setenv("BAD_SYNTAX","1.0")..."]:2: unexpected symbol near '#'
+     ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua :
+[string "setenv("BAD_SYNTAX","1.0")..."]:2: unexpected symbol near '#'
 While processing the following module(s):
     Module fullname  Module Filename
     bad_syntax/1.0   ProjectDIR/rt/errHandler/mf/bad_syntax/1.0.lua
```

* `hook`
```
--- rt/hook//err.txt	2016-06-10 21:05:59.214541290 +0000
+++ rt/hook//t1/2016_06_10_21_06_32-Linux-x86_64-hook/err.txt	2016-06-10 21:06:43.022013182 +0000
@@ -2,7 +2,7 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua bash --version
 ===========================
-Modules based on Lua: Version 5.0.1 (5.0.1-48-g540fa7d) 2013-06-18 14:14
+Modules based on Lua: Version 6.4.1  2016-06-04 08:48
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
@@ -12,3 +12,5 @@
 step 3
 lua ProjectDIR/src/lmod.in.lua bash load admin intel
 ===========================
+sh: 1: uuidgen: not found
+sh: 1: uuidgen: not found
```

* `modulerc`
```
--- rt/modulerc//err.txt	2016-06-10 21:05:59.222541194 +0000
+++ rt/modulerc//t1/2016_06_10_21_06_32-Linux-x86_64-modulerc/err.txt	2016-06-10 21:06:58.417827616 +0000
@@ -2,7 +2,7 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua bash --version
 ===========================
-Modules based on Lua: Version 6.0.19  2015-11-18 08:32
+Modules based on Lua: Version 6.4.1  2016-06-04 08:48
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
@@ -154,4 +154,5 @@
 ===========================
 The default cluster module cannot be determined. Please set $VSC_DEFAULT_CLUSTER_MODULE.
 Lmod has detected the following error: Unable to parse:
-ProjectDIR/rt/modulerc/mf2/Core/cluster/.modulerc  Aborting!
+ProjectDIR/rt/modulerc/mf2/Core/cluster/.modulerc
+Aborting!
```