### PR TITLE
Extend msgHook to LmodError and LmodWarning

### DIFF
--- a/docs/source/170_hooks.rst
+++ b/docs/source/170_hooks.rst
@@ -78,7 +78,7 @@ Hook functions
   family prefix:  ``site_FAMILY_``
 
 **msgHook**(...):
-  Hook to print messages after avail, list, spider.
+  Hook to print messages after avail, list, spider, LmodError and LmodWarning.
 
 **groupName**(...):
   This hook adds the arch and os name to moduleT.lua to make it safe

--- a/src/Hook.lua
+++ b/src/Hook.lua
@@ -55,7 +55,7 @@ local validT =
                                -- It is used to generate family
                                -- prefix:  site_FAMILY_
       msgHook        = false,  -- Hook to print messages after:
-                               -- avail, list, spider
+                               -- avail, list, spider, LmodError and LmodWarning
       groupName      = false,  -- This hook adds the arch and os name
                                -- to moduleT.lua to make it safe on
                                -- shared filesystems.

--- a/src/MasterControl.lua
+++ b/src/MasterControl.lua
@@ -83,6 +83,7 @@ local concatTbl    = table.concat
 local decode64     = base64.decode64
 local encode64     = base64.encode64
 local getenv       = os.getenv
+local hook         = require("Hook")
 local remove       = table.remove
 local pack         = (_VERSION == "Lua 5.1") and argsPack or table.pack
 local Exit         = os.exit
@@ -762,15 +763,22 @@ end
 function LmodSystemError(...)
    local label  = colorize("red", "Lmod has detected the following error: ")
    local twidth = TermWidth()
-   local s      = buildMsg(twidth, label, ...)
-   io.stderr:write(s,"\n")
+   local s      = {}
+   s[#s+1] = buildMsg(twidth, label, ...)
+   s[#s+1] = "\n"
    
-   s = concatTbl(stackTraceBackA,"")
-   if (s:len() > 0) then
-      io.stderr:write(s,"\n")
+   local a = concatTbl(stackTraceBackA,"")
+   if (a:len() > 0) then
+       s[#s+1] = a
+       s[#s+1] = "\n"
    end
 
-   s = moduleStackTraceBack()
+   s[#s+1] = moduleStackTraceBack()
+   s[#s+1] = "\n"
+
+   s = hook.apply("msgHook","lmoderror",s)
+   s = concatTbl(s,"")
+
    io.stderr:write(s,"\n")
    LmodErrorExit()
 end

--- a/src/MasterControl.lua
+++ b/src/MasterControl.lua
@@ -798,9 +798,16 @@ function M.warning(self, ...)
    if (not quiet() and  haveWarnings()) then
       local label  = colorize("red", "Lmod Warning: ")
       local twidth = TermWidth()
-      local s      = buildMsg(twidth, label, ...)
+      local s      = {}
+      s[#s+1] = buildMsg(twidth, label, ...)
+      s[#s+1] = "\n"
+      s[#s+1] = moduleStackTraceBack()
+      s[#s+1] = "\n"
+
+      s = hook.apply("msgHook","lmodwarning",s)
+      s = concatTbl(s,"")
+
       io.stderr:write(s,"\n")
-      io.stderr:write(moduleStackTraceBack(),"\n")
       setWarningFlag()
    end
 end


### PR DESCRIPTION
I pass the full array/table of the error/warning to the hook, so manipulation is possible.