### PR TITLE
fall back to 'shasum -a 1' in case sha1sum is not available in computeHashSum

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -351,12 +351,12 @@ fi
 AC_PATH_PROG(PATH_TO_GIT, git, "")
 AC_PATH_PROG(PATH_TO_PAGER,[less] [more], [more])
 
-AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [md5sum] [gmd5sum] [md5], UNKNOWN)
+AC_PATH_PROGS(PATH_TO_HASHSUM, [sha1sum] [gsha1sum] [shasum] [md5sum] [gmd5sum] [md5], UNKNOWN)
 if test "`basename $PATH_TO_HASHSUM`" = "md5" ; then
   PATH_TO_HASHSUM="$PATH_TO_HASHSUM -r"
 elif test "$PATH_TO_HASHSUM" = "UNKNOWN" ; then
   echo
-  echo "You must have either sha1sum, md5sum or md5 in your path. Quitting!"
+  echo "You must have either sha1sum, shasum, md5sum or md5 in your path. Quitting!"
   echo
   exit
 fi

--- a/src/computeHashSum.in.lua
+++ b/src/computeHashSum.in.lua
@@ -169,7 +169,7 @@ function main()
    end
    fh:write(s)
    if (HashSum:sub(1,1) == "@" ) then
-      HashSum = find_exec_path("sha1sum")
+      HashSum = find_exec_path("sha1sum") or find_exec_path("shasum")
    end
    fh:close()
 


### PR DESCRIPTION
`sha1sum` is not available on OS X, but `shasum` is:

```
$ shasum README
e3d79ad5a9ffcb8194b94742affa5db9a221a208  README
```