### PR TITLE
fix determining of exit status in capture function for Lua 5.1

### DIFF
--- a/tools/capture.lua
+++ b/tools/capture.lua
@@ -76,7 +76,7 @@ function capture(cmd, envT)
          LmodError("Failed to find '" .. ec_msg .. "' in output: " .. out)
       end
       status = exit_code == '0'
-      out = out:gsub("exit code: %d+\n$", '')
+      out = out:gsub(ec_msg .. ": %d+\n$", '')
    end
 
    for k, v in pairs(newT) do

--- a/tools/capture.lua
+++ b/tools/capture.lua
@@ -71,15 +71,12 @@ function capture(cmd, envT)
 
    -- trim 'exit code: <value>' from the end of the output and determine exit status
    if _VERSION == "Lua 5.1" then
-      local idx, _, ec_idx, ec_str
-      idx, _ = string.find(out, ec_msg, -20)
-      if idx == nil then
+      local exit_code = out:match(ec_msg .. ": (%d+)\n$")
+      if not exit_code then
          LmodError("Failed to find '" .. ec_msg .. "' in output: " .. out)
       end
-      ec_str = out:sub(idx)
-      ec_idx = string.find(ec_str, ":") + 2
-      status = (ec_str:sub(ec_idx) == "0\n")
-      out = out:sub(0, idx-1)
+      status = exit_code == '0'
+      out = out:gsub("exit code: %d+\n$", '')
    end
 
    for k, v in pairs(newT) do

--- a/tools/capture.lua
+++ b/tools/capture.lua
@@ -38,7 +38,7 @@ local getenv       = os.getenv
 local setenv_posix = posix.setenv
 
 --------------------------------------------------------------------------
--- Capture stdout from *cmd*
+-- Capture output and exit status from *cmd*
 -- @param cmd A string that contains a unix command.
 -- @param envT A table that contains environment variables to be set/restored when running *cmd*.
 function capture(cmd, envT)
@@ -54,12 +54,32 @@ function capture(cmd, envT)
       setenv_posix(k, v, true)
    end
 
-   local ret
+   -- in Lua 5.1, p:close() does not return exit status,
+   -- so we append 'echo $?' to the command to determine the exit status
+   local ec_msg = "exit code"
+   if _VERSION == "Lua 5.1" then
+      cmd = cmd .. '; echo "' .. ec_msg .. ': $?"'
+   end
+
+   local out
    local status
    local p   = io.popen(cmd)
    if (p ~= nil) then
-      ret    = p:read("*all")
+      out    = p:read("*all")
       status = p:close()
+   end
+
+   -- trim 'exit code: <value>' from the end of the output and determine exit status
+   if _VERSION == "Lua 5.1" then
+      local idx, _, ec_idx, ec_str
+      idx, _ = string.find(out, ec_msg, -20)
+      if idx == nil then
+         LmodError("Failed to find '" .. ec_msg .. "' in output: " .. out)
+      end
+      ec_str = out:sub(idx)
+      ec_idx = string.find(ec_str, ":") + 2
+      status = (ec_str:sub(ec_idx) == "0\n")
+      out = out:sub(0, idx-1)
    end
 
    for k, v in pairs(newT) do
@@ -68,11 +88,11 @@ function capture(cmd, envT)
 
    if (dbg.active()) then
       dbg.start{"capture output()",level=2}
-      dbg.print{ret}
+      dbg.print{out}
       dbg.fini("capture output")
    end
    dbg.print{"status: ",status,", type(status): ",type(status),"\n"}
    dbg.fini("capture")
-   return ret, status
+   return out, status
 end
 


### PR DESCRIPTION
I need this change (together with #134) to make all tests pass on my system (OS X El Capitan w/ Lua 5.1 installed via the tarball provided in the Lmod repo)