### PR TITLE
make git branch tweakable for 'make dist'

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -51,6 +51,7 @@ MODULEPATH_ROOT   	  := @MODULEPATH_ROOT@
 VERSION_SRC	  	  := $(srcdir)/src/Version.lua
 LUA_INCLUDE       	  := @LUA_INCLUDE@
 UPDATE_SYSTEM_FN  	  := @UPDATE_SYSTEM_FN@
+GIT_BRANCH                := master
 GIT_PROG                  := @PATH_TO_GIT@
 GIT_VERSION               := $(shell if [ -n "$(GIT_PROG)" -a -d .git ]; then lmodV=`git describe --always`; echo "($$lmodV)"; else echo "@git@"; fi)
 prefix		  	  := @prefix@
@@ -260,7 +261,7 @@ config.status:
 	./config.status --recheck
 
 dist:
-	git archive --prefix=Lmod-$(version)/ master > Lmod-$(version).tar
+	git archive --prefix=Lmod-$(version)/ $(GIT_BRANCH) > Lmod-$(version).tar
 	$(RM) -rf DIST;                               			     	 \
         mkdir DIST;                                   			     	 \
         cd DIST;                                      			     	 \

--- a/rt/end2end/end2end.tdesc
+++ b/rt/end2end/end2end.tdesc
@@ -35,7 +35,7 @@ testdescript = {
      echo LmodV=$LmodV
      mkdir b0
      (cd b0; $(projectDir)/configure --prefix=$(outputDir)/b0)
-     (cd $(projectDir); make -f $(outputDir)/b0/makefile dist)
+     (cd $(projectDir); make -f $(outputDir)/b0/makefile dist GIT_BRANCH=HEAD)
      tar xf $projectDir/Lmod-$LmodV.tar.bz2
      rm -rf $projectDir/Lmod-$LmodV.tar.bz2
      mkdir build; cd build; ../Lmod-$LmodV/configure --prefix=`pwd`/..;


### PR DESCRIPTION
This fixes the failing `end2end` test in Travis (cfr.#130), because for pull requests to `master` branch isn't there by default when the Lmod repository is cloned; instead, the tests are run on a 'detached head', because Travis tests the *merge commit* rather than the top-level commit of the PR.

This change should be backward compatible, and the fix is verified in Travis (cfr. https://travis-ci.org/boegel/Lmod/jobs/138170813).