### PR TITLE
use /proc/sys/kernel/random/uuid as fallback in case uuidgen is not available

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -815,7 +815,21 @@ function UUIDString(epoch)
                                    ymd.year, ymd.month, ymd.day,
                                    ymd.hour, ymd.min,   ymd.sec)
 
-   local uuid_str  = capture("uuidgen"):sub(1,-2)
+   local uuidgen = find_exec_path('uuidgen')
+   local uuid_str
+   if uuidgen then
+       uuid_str = capture('uuidgen'):sub(1,-2)
+   else
+      -- if uuidgen is not available, fall back to reading /proc/sys/kernel/random/uuid
+      -- note: only works on Linux
+      local f = io.open('/proc/sys/kernel/random/uuid', 'r')
+      if f then
+         uuid_str = f:read('*all'):sub(1,-2)
+      else
+         LmodError("uuidgen is not available, fallback failed too")
+      end
+   end
+
    local uuid      = uuid_date .. "-" .. uuid_str
 
    return uuid


### PR DESCRIPTION
This also refers to #130: installing `uuidgen` on Travis is kind of difficult because the `uuid-runtime` package can not be installed via the usual `apt-get` (yet, it is not whitelisted yet because of potential security issues).

With this fallback in place, the `hook` test passes on Travis (cfr. https://travis-ci.org/boegel/Lmod/jobs/138178684), where it previously failed with `sh: 1: uuidgen: not found`

@rtmclay I also noticed that the `configure` script isn't checking whether `uuidgen` is available at all, even though Lmod does call out to `uuidgen` sometimes... That should probably be fixed as well (with this fallback in mind)?