### PR TITLE
Unset LD_PRELOAD before running tcl2lua

### DIFF
--- a/src/MAlias.lua
+++ b/src/MAlias.lua
@@ -165,6 +165,7 @@ function M.resolve(self, name)
          if (isFile(fn)) then
             local a   = {}
             a[#a + 1] = "LD_LIBRARY_PATH=\"".. (LMOD_LD_LIBRARY_PATH or "") .. "\""
+            a[#a + 1] = "LD_PRELOAD=\"\""
             a[#a + 1] = LMOD_TCLSH
             a[#a + 1] = pathJoin(cmdDir(),"RC2lua.tcl")
             a[#a + 1] = fn

--- a/src/loadModuleFile.lua
+++ b/src/loadModuleFile.lua
@@ -104,12 +104,13 @@ function loadModuleFile(t)
          A[#A + 1]    = "-L"
          A[#A + 1]    = "\"" .. ldlib .. "\""
       end
-      
+
       if (t.help) then
          A[#A + 1] = "-h"
       end
       local a      = {}
       a[#a + 1]    = "LD_LIBRARY_PATH=\"".. (LMOD_LD_LIBRARY_PATH or "") .. "\""
+      a[#a + 1]    = "LD_PRELOAD=\"\""
       a[#a + 1]    = LMOD_TCLSH
       a[#a + 1]	   = pathJoin(cmdDir(),"tcl2lua.tcl")
       a[#a + 1]	   = concatTbl(A," ")

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -866,6 +866,7 @@ function versionFile(v, sn, path, ignoreErrors)
    dbg.print{"handle file: ",v, "\n"}
    local a = {}
    a[#a + 1] = "LD_LIBRARY_PATH=\"".. (LMOD_LD_LIBRARY_PATH or "") .. "\""
+   a[#a + 1] = "LD_PRELOAD=\"\""
    a[#a + 1] = LMOD_TCLSH
    a[#a + 1] = pathJoin(cmdDir(),"RC2lua.tcl")
    a[#a + 1] = path
@@ -1071,7 +1072,7 @@ function walk_directory_for_mf(mpath, path, prefix, dirA, mnameT)
          local file    = v.file
          local mypath  = v.path
          local pathEsc = "^" .. mypath:escape() .. "/"
-      
+
          for root, mydirA, fileA in dir_walk(pathJoin(mypath,file)) do
             for ja = 1, #fileA do
                local f       = pathJoin(root,fileA[ja])


### PR DESCRIPTION
We got bitten in the ass by this through `jemalloc`. This sets a `LD_PRELOAD` which breaks `tclsh` if the `LD_LIBRARY_PATH` is empty.

As this code is in three places, it might be a good idea to make a single function for it? @rtmclay what do you think?