### PR TITLE
Improved lmod_bash_completions

### DIFF
--- a/init/lmod_bash_completions
+++ b/init/lmod_bash_completions
@@ -1,21 +1,62 @@
+
 _module_avail() {
-	@PKG@/libexec/lmod bash -t avail  2>&1 > /dev/null | sed ' /:$/d; s#/*$##g;'
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		#
+		# Lmod output already redirected to STDOUT: do not redirect again; just parse.
+		#
+		@PKG@/libexec/lmod bash -t avail 2>/dev/null | bash | sed ' /:$/d; s#/*$##g;'
+	else
+		#
+		# Lmod output goes to STDERR by default, but for bash redirection we need it on STOUT.
+		#
+		@PKG@/libexec/lmod bash -t avail 2>&1 >/dev/null | sed ' /:$/d; s#/*$##g;'
+	fi
 }
 
 _module_spider() {
-	@PKG@/libexec/lmod bash -t spider  2>&1 > /dev/null
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		@PKG@/libexec/lmod bash -t spider 2>/dev/null | bash
+	else
+		@PKG@/libexec/lmod bash -t spider 2>&1 >/dev/null
+	fi
 }
 
 _module_loaded_modules() {
-	@PKG@/libexec/lmod bash -t list  2>&1 > /dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g;'
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		@PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g;'
+	else
+		@PKG@/libexec/lmod bash -t list 2>&1 >/dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g;'
+	fi
 }
 
 _module_savelist() {
-	@PKG@/libexec/lmod bash -t savelist  2>&1 > /dev/null
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		@PKG@/libexec/lmod bash -t savelist 2>/dev/null | bash
+	else
+		@PKG@/libexec/lmod bash -t savelist 2>&1 >/dev/null
+	fi
 }
 
 _module_loaded_modules_negated() {
-	@PKG@/libexec/lmod bash -t list  2>&1 > /dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		@PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
+	else
+		@PKG@/libexec/lmod bash -t list 2>&1 >/dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
+	fi
+}
+
+_module_mcc() {
+	local redirect="${LMOD_REDIRECT:-false}"
+	if ${redirect,,}; then
+		@PKG@/libexec/lmod bash -t collection 2>/dev/null | bash
+	else
+		@PKG@/libexec/lmod bash -t collection 2>&1 >/dev/null
+	fi
 }
 
 _module_not_yet_loaded() {
@@ -23,146 +64,170 @@ _module_not_yet_loaded() {
 }
 
 _module_long_arg_list() {
-	local cur="$1" i
-
+	local cur="${1}" i
+	
 	if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]; then
-		COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "$cur") )
+		COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
 		return
 	fi
 	for ((i = COMP_CWORD - 1; i > 0; i--)); do
-	  case ${COMP_WORDS[$i]} in
-	    add|load)
-		COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "$cur") )
-		break;;
-	    rm|remove|unload|switch|swap)
-		COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "$cur") )
-		break;;
-	  esac
+		case ${COMP_WORDS[${i}]} in
+		add|load)
+			COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
+			break
+			;;
+		rm|remove|unload|switch|swap)
+			COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "${cur}") )
+			break
+			;;
+		esac
 	done
 }
 
-_module_mcc() {
-	@PKG@/libexec/lmod bash -t collection 2>&1 > /dev/null
-
-}
-
 _module() {
-	local cur="$2" prev="$3" cmds opts
-
+	local cur="${2}" prev="${3}" cmds opts
+	
 	COMPREPLY=()
-
+	
 	cmds="add avail delete help keyword list load purge rm restore save show spider swap \
 	      unload unuse update use whatis"
-
-	opts="-d -D -h -q -t -v -w  -s --style --expert --quiet --help  --quiet --terse --version --default --width -r --regexp --mt"
-
-	case "$prev" in
-	add|load|try-load)
-                        COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "$cur") );;
-        restore)        COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "$cur") );;
-        spider)         COMPREPLY=( $(compgen -W "$(_module_spider)" -- "$cur") );;
-	rm|remove|unload|switch|swap)
-			COMPREPLY=( $(      compgen -W "$(_module_loaded_modules)" -- "$cur") );;
-	unuse)		COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
-	use|*-a*)	_filedir -d || return 0;;
-	help|show|whatis)
-			COMPREPLY=( $(compgen -W "$(_module_avail)" -- "$cur") );;
-	collection|cc|mcc)
-			COMPREPLY=( $(compgen -W "$(_module_mcc)" -- "$cur") );;
 	
-	*) if test $COMP_CWORD -gt 2
-	   then
-		_module_long_arg_list "$cur"
-	   else
-		case "$cur" in
-		# The mappings below are optional abbreviations for convenience
-		ls)	COMPREPLY="list";;	# map ls -> list
-		sw*)	COMPREPLY="swap";;
-
-		-*)	COMPREPLY=( $(compgen -W "$opts" -- "$cur") );;
-		*)	COMPREPLY=( $(compgen -W "$cmds" -- "$cur") );;
-		esac
-	   fi;;
+	opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help --quiet --terse --version --default --width -r --regexp --mt"
+	
+	case "${prev}" in
+	add|load|try-load)
+		COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
+		;;
+	rm|remove|unload|switch|swap)
+		COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "${cur}") )
+		;;
+	restore)
+		COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "${cur}") )
+		;;
+	spider)
+		COMPREPLY=( $(compgen -W "$(_module_spider)" -- "${cur}") )
+		;;
+	unuse)
+		COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
+		;;
+	use|*-a*)
+		_filedir -d || return 0
+		;;
+	help|show|whatis)
+		COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
+		;;
+	collection|cc|mcc)
+		COMPREPLY=( $(compgen -W "$(_module_mcc)" -- "${cur}") )
+		;;
+	*)
+		if [ ${COMP_CWORD} -gt 2 ]; then
+			_module_long_arg_list "${cur}"
+		else
+			case "${cur}" in
+			# The mappings below are optional abbreviations for convenience
+			ls)
+				COMPREPLY='list'
+				;;
+			sw*)
+				COMPREPLY='swap'
+				;;
+			-*)
+				COMPREPLY=( $(compgen -W "${opts}" -- "${cur}") )
+				;;
+			*)
+				COMPREPLY=( $(compgen -W "${cmds}" -- "${cur}") )
+				;;
+			esac
+		fi
+		;;
 	esac
 }
-complete  -F _module module
+complete -F _module module
 
 _ml() {
-  local cur="$2" prev="$3" cmds opts found
-  #echo cur=%$cur% prev=%$prev% >> $HOME/t/ml.log
-
-  COMPREPLY=()
-
-  cmds="add avail delete help keyword list load purge rm restore save sl show spider swap unload \
-        unuse update use whatis"
-
-  opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help  --quiet --terse --version --default --Verbose --width -r --regexp --mt"
-
-  #echo 2  >> $HOME/t/ml.log
-
-
-  case "$prev" in
-    spider)         COMPREPLY=( $(compgen -W "$(_module_spider)" -- "$cur") );;
-    rm|remove|unload|swap)
-                    COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "$cur") );;
-    restore)        COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "$cur") );;
-    unuse)	    COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "$cur") );;
-    use|*-a*)       _filedir -d || return 0;;
-    help|show|whatis)
-                    COMPREPLY=( $(compgen -W "$(_module_avail)" -- "$cur") );;
-
-    *)
-       case "$cur" in
-         -*)
-            #echo a >> $HOME/t/ml.log
-            if [ $COMP_CWORD -eq 1 ]; then
-              COMPREPLY=( $(compgen -W "$opts $(_module_loaded_modules_negated)" -- "$cur") )
-            else
-              COMPREPLY=( $(compgen -W "      $(_module_loaded_modules_negated)" -- "$cur") )
-            fi;;
-         *)
-            #echo 3 >> $HOME/t/ml.log
-            if [ $COMP_CWORD -eq 1 ]; then
-              case "$cur" in
-                ls)  COMPREPLY="list";;      # map ls -> list
-                sw*) COMPREPLY="swap";;
-                *)
-                  #echo 4 >> $HOME/t/ml.log
-                  COMPREPLY=( $(compgen -W "$cmds $(_module_avail)" -- "$cur") );;
-              esac
-            else
-	      if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]; then
-	        COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "$cur") )
-              else
-	        for ((i = COMP_CWORD - 1; i > 0; i--)); do
-	          case ${COMP_WORDS[$i]} in
-	            show|whatis)
-	    	  COMPREPLY=( $(compgen -W "$(_module_avail)" -- "$cur") )
-                      found=1
-	    	  break;;
-	            rm|remove|unload)
-	    	  COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "$cur") )
-                      found=1
-	    	  break;;
-                    spider)
-                      COMPREPLY=( $(compgen -W "$(_module_spider)" -- "$cur") )
-                      found=1
-	    	  break;;
-	          esac
-	        done
-                if [ -z "$found" ]; then
-                  COMPREPLY=( $(compgen -W "$(_module_avail)" -- "$cur") )
-                fi
-              fi
-            fi;;
-       esac
-  esac
-
-  #echo 5 >> $HOME/t/ml.log
+	local cur="${2}" prev="${3}" cmds opts found
+	
+	COMPREPLY=()
+	
+	cmds="add avail delete help keyword list load purge rm restore save sl show spider swap \
+	      unload unuse update use whatis"
+	
+	opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help  --quiet --terse --version --default --Verbose --width -r --regexp --mt"
+	
+	case "${prev}" in
+	rm|remove|unload|swap)
+		COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "${cur}") )
+		;;
+	restore)
+		COMPREPLY=( $(compgen -W "$(_module_savelist)" -- "${cur}") )
+		;;
+	spider)
+		COMPREPLY=( $(compgen -W "$(_module_spider)" -- "${cur}") )
+		;;
+	unuse)
+		COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
+		;;
+	use|*-a*)
+		_filedir -d || return 0
+		;;
+	help|show|whatis)
+		COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
+		;;
+	*)
+		case "${cur}" in
+		-*)
+			if [ ${COMP_CWORD} -eq 1 ]; then
+				COMPREPLY=( $(compgen -W "${opts} $(_module_loaded_modules_negated)" -- "${cur}") )
+			else
+				COMPREPLY=( $(compgen -W "        $(_module_loaded_modules_negated)" -- "${cur}") )
+			fi
+			;;
+		*)
+			if [ ${COMP_CWORD} -eq 1 ]; then
+				case "${cur}" in
+				ls)
+					COMPREPLY='list'
+					;;
+				sw*)
+					COMPREPLY='swap'
+					;;
+				*)
+					COMPREPLY=( $(compgen -W "${cmds} $(_module_avail)" -- "${cur}") )
+					;;
+				esac
+			else
+				if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]; then
+					COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
+				else
+					for ((i = COMP_CWORD - 1; i > 0; i--)); do
+						case ${COMP_WORDS[$i]} in
+						show|whatis)
+							COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
+							found=1
+							break
+							;;
+						rm|remove|unload)
+							COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "${cur}") )
+							found=1
+							break
+							;;
+						spider)
+							COMPREPLY=( $(compgen -W "$(_module_spider)" -- "${cur}") )
+							found=1
+							break
+							;;
+						esac
+					done
+					if [ -z "${found}" ]; then
+						COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
+					fi
+				fi
+			fi
+			;;
+		esac
+	esac
 }
-
-complete  -F _ml ml
-
+complete -F _ml ml
 
 # Local Variables:
 # mode: shell-script

--- a/init/lmod_bash_completions
+++ b/init/lmod_bash_completions
@@ -155,7 +155,7 @@ _ml() {
 	opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help  --quiet --terse --version --default --Verbose --width -r --regexp --mt"
 	
 	case "${prev}" in
-	rm|remove|unload|swap)
+	rm|remove|unload|switch|swap)
 		COMPREPLY=( $(compgen -W "$(_module_loaded_modules)" -- "${cur}") )
 		;;
 	restore)

--- a/init/lmod_bash_completions
+++ b/init/lmod_bash_completions
@@ -111,7 +111,16 @@ _module() {
 		COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
 		;;
 	use|*-a*)
-		_filedir -d || return 0
+		_filedir -d 2>/dev/null || {
+			COMPREPLY=( $(compgen -d -- "${cur}") )
+			if [[ ${#COMPREPLY[@]} -eq 1 ]]; then
+				local dir=${COMPREPLY[0]}
+				if [[ ${dir} != "*/" ]]; then
+					COMPREPLY[0]="${dir}/"
+					compopt -o nospace
+				fi
+			fi
+		}
 		;;
 	help|show|whatis)
 		COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
@@ -168,7 +177,16 @@ _ml() {
 		COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
 		;;
 	use|*-a*)
-		_filedir -d || return 0
+		_filedir -d 2>/dev/null || {
+			COMPREPLY=( $(compgen -d -- "${cur}") )
+			if [[ ${#COMPREPLY[@]} -eq 1 ]]; then
+				local dir=${COMPREPLY[0]}
+				if [[ ${dir} != "*/" ]]; then
+					COMPREPLY[0]="${dir}/"
+					compopt -o nospace
+				fi
+			fi
+		}
 		;;
 	help|show|whatis)
 		COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )


### PR DESCRIPTION
* Added support for ${LMOD_REDIRECT}
* Fixed bug where "ml rm <TAB>" would list all available modules as opposed to loaded ones that can be removed.
* Indentation used a mix of tabs and spaces: standardized for now on tabs for indentation.