### PR TITLE
reset $LD_LIBRARY_PATH and $LD_PRELOAD before forking off shell to run tcl2lua

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -844,14 +844,14 @@ modA = false
 
 function runTCLprog(TCLprog, optStr, fn)
    local a   = {}
-   a[#a + 1] = "LD_LIBRARY_PATH=\"".. (LMOD_LD_LIBRARY_PATH or "") .. "\""
-   a[#a + 1] = "LD_PRELOAD=\""..      (LMOD_LD_PRELOAD      or "") .. "\""
    a[#a + 1] = LMOD_TCLSH
    a[#a + 1] = pathJoin(cmdDir(),TCLprog)
    a[#a + 1] = optStr or ""
    a[#a + 1] = fn
    local cmd = concatTbl(a," ")
-   local whole, status = capture(cmd)
+   -- reset $LD_LIBRARY_PATH and $LD_PRELOAD, to avoid that they break the subshell forked by io.popen in capture
+   local reset_envvars = {LD_LIBRARY_PATH="", LD_PRELOAD=""}
+   local whole, status = capture(cmd, reset_envvars)
    return whole, status
 end
    

--- a/tools/capture.lua
+++ b/tools/capture.lua
@@ -50,7 +50,9 @@ function capture(cmd, envT)
    local newT = {}
    envT = envT or {}
    for k, v in pairs(envT) do
+      dbg.print{"envT[",k,"]=",v,"\n"}
       newT[k] = getenv(k)
+      dbg.print{"newT[",k,"]=",newT[k],"\n"}
       setenv_posix(k, v, true)
    end
 


### PR DESCRIPTION
In very particular circumstances (*cough* EasyBuild *cough*), we were seeing problems where the subshell that is forked by the `io.popen` via `capture` was broken because of an `$LD_PRELOAD` being set without that the paths to the libraries reloaded by that preloaded library are listed in `$LD_LIBRARY_PATH`

This patch (partially) fixes this problem, by resetting `$LD_LIBRARY_PATH` and `$LD_PRELOAD` *before* `capture`, rather than as a part of the command being executed by `capture`.

Although this patch fixes the problem we are seeing, it seems like this patch is incomplete, since the error caused by the preloaded library also seems to be occurring in other (less destructive) places.

A better fix may be to simply *always* hard reset `$LD_LIBRARY_PATH` and `$LD_PRELOAD` in `capture` (or even whenever an `io.popen` is being called).