### PR TITLE
Added support for environment variables as well as ~ in bash autocompletion.

### DIFF
--- a/init/lmod_bash_completions
+++ b/init/lmod_bash_completions
@@ -2,10 +2,10 @@
 _module_avail() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      #
-      # Lmod output already redirected to STDOUT: do not redirect again; just parse.
-      #
-      @PKG@/libexec/lmod bash -t avail 2>/dev/null | bash | sed ' /:$/d; s#/*$##g;'
+    #
+    # Lmod output already redirected to STDOUT: do not redirect again; just parse.
+    #
+    @PKG@/libexec/lmod bash -t avail 2>/dev/null | bash | sed ' /:$/d; s#/*$##g;'
   else
     #
     # Lmod output goes to STDERR by default, but for bash redirection we need it on STOUT.
@@ -14,21 +14,68 @@ _module_avail() {
   fi
 }
 
-_module_filedir() {
-  COMPREPLY=( $(compgen -d -- "${cur}") )
+_module_dir() {
+  local cur="${1}" pattern i
+  if [[ "${cur:0:1}" == '$' ]]; then
+    pattern='^\$[[:alnum:]_]+\/$'
+    if [[ ${cur} =~ ${pattern} ]]; then
+      #
+      # Resolve variable into value.
+      #
+      eval COMPREPLY[0]="${cur}"
+    else
+      #
+      # Complete exported environment variables
+      # and remove any matches that don't contain a directory.
+      #
+      COMPREPLY=( $( compgen -v -P '$' -- "${cur#?(\\)$}" ) )
+      local -a FILTEREDCOMPREPLY
+      for ((i=0; i < ${#COMPREPLY[@]}; i++)); do
+        pattern='^\$[[:alnum:]_]+$'
+        if [[ ${COMPREPLY[$i]} =~ ${pattern} ]]; then
+          eval local env_val="${COMPREPLY[$i]}"
+          if [ -d "${env_val}" ]; then
+            FILTEREDCOMPREPLY+=(${COMPREPLY[$i]})
+          fi
+        fi
+      done
+      COMPREPLY=( ${FILTEREDCOMPREPLY[@]} )
+    fi
+  elif [[ "${cur:0:1}" == '~' ]]; then
+    if [[ "${cur}" != "${cur//\/}" ]]; then
+      #
+      # ${cur} contains a slash:
+      # 1: Remove * including and after first slash (/), i.e. "~a/b"
+      #    becomes "~a".  Double quotes allow eval.
+      # 2: Remove * before the first slash (/), i.e. "~a/b"
+      #    becomes 'b'.  Single quotes prevent eval.
+      #                 +-----1-----+ +-----2----+
+      eval COMPREPLY[0]="${cur%%\/*}"/'${cur#*\/}'
+    else
+      #
+      # ${cur} doesn't contain slash.
+      #
+      eval COMPREPLY[0]="~"
+    fi
+  else
+    #
+    # Complete directories.
+    #
+    COMPREPLY=( $(compgen -d -- "${cur}") )
+  fi
   if [[ ${#COMPREPLY[@]} -eq 1 ]]; then
-      local dir=${COMPREPLY[0]}
-      if [[ ${dir} != "*/" ]]; then
-          COMPREPLY[0]="${dir}/"
-          compopt -o nospace
-      fi
+    pattern='\/$'
+    if [[ -d "${COMPREPLY[0]}" && ! "${COMPREPLY[0]}" =~ ${pattern} ]]; then
+      COMPREPLY[0]="${COMPREPLY[0]}/"
+    fi
+    compopt -o nospace
   fi
 }
 
 _module_spider() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      @PKG@/libexec/lmod bash -t spider 2>/dev/null | bash
+    @PKG@/libexec/lmod bash -t spider 2>/dev/null | bash
   else
     @PKG@/libexec/lmod bash -t spider 2>&1 >/dev/null
   fi
@@ -37,7 +84,7 @@ _module_spider() {
 _module_loaded_modules() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      @PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g;'
+    @PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g;'
   else
     @PKG@/libexec/lmod bash -t list 2>&1 >/dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g;'
   fi
@@ -46,7 +93,7 @@ _module_loaded_modules() {
 _module_savelist() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      @PKG@/libexec/lmod bash -t savelist 2>/dev/null | bash
+    @PKG@/libexec/lmod bash -t savelist 2>/dev/null | bash
   else
     @PKG@/libexec/lmod bash -t savelist 2>&1 >/dev/null
   fi
@@ -55,7 +102,7 @@ _module_savelist() {
 _module_loaded_modules_negated() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      @PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
+    @PKG@/libexec/lmod bash -t list 2>/dev/null | bash | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
   else
     @PKG@/libexec/lmod bash -t list 2>&1 >/dev/null | sed ' /^ *$/d; /:$/d; s#/*$##g; s|^|-|g;'
   fi
@@ -64,7 +111,7 @@ _module_loaded_modules_negated() {
 _module_mcc() {
   local redirect="${LMOD_REDIRECT:-false}"
   if ${redirect,,}; then
-      @PKG@/libexec/lmod bash -t collection 2>/dev/null | bash
+    @PKG@/libexec/lmod bash -t collection 2>/dev/null | bash
   else
     @PKG@/libexec/lmod bash -t collection 2>&1 >/dev/null
   fi
@@ -76,10 +123,9 @@ _module_not_yet_loaded() {
 
 _module_long_arg_list() {
   local cur="${1}" i
-  
   if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]; then
-      COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
-      return
+    COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
+    return
   fi
   for ((i = COMP_CWORD - 1; i > 0; i--)); do
     case ${COMP_WORDS[${i}]} in
@@ -100,10 +146,11 @@ _module() {
   
   COMPREPLY=()
   
-  cmds="add avail delete help keyword list load purge rm restore save show spider swap \
-              unload unuse update use whatis"
+  cmds="add avail delete help keyword list load purge rm restore \
+        save show spider swap unload unuse update use whatis"
   
-  opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help --quiet --terse --version --default --width -r --regexp --mt"
+  opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help \
+        --quiet --terse --version --default --width -r --regexp --mt"
   
   case "${prev}" in
     add|load|try-load)
@@ -122,7 +169,7 @@ _module() {
       COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
       ;;
     use|*-a*)
-      _filedir -d 2>/dev/null || _module_filedir
+      _module_dir "${cur}"
       ;;
     help|show|whatis)
       COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
@@ -132,10 +179,10 @@ _module() {
       ;;
     *)
       if [ ${COMP_CWORD} -gt 2 ]; then
-          _module_long_arg_list "${cur}"
+        _module_long_arg_list "${cur}"
       else
         case "${cur}" in
-          # The mappings below are optional abbreviations for convenience
+          # The mappings below are optional abbreviations for convenience.
           ls)
             COMPREPLY='list'
             ;;
@@ -160,10 +207,11 @@ _ml() {
   
   COMPREPLY=()
   
-  cmds="add avail delete help keyword list load purge rm restore save sl show spider swap \
-              unload unuse update use whatis"
+  cmds="add avail delete help keyword list load purge rm restore \
+        save sl show spider swap unload unuse update use whatis"
   
-  opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help  --quiet --terse --version --default --Verbose --width -r --regexp --mt"
+  opts="-d -D -h -q -t -v -w -s --style --expert --quiet --help \
+        --quiet --terse --version --default --Verbose --width -r --regexp --mt"
   
   case "${prev}" in
     rm|remove|unload|switch|swap)
@@ -179,7 +227,7 @@ _ml() {
       COMPREPLY=( $(IFS=: compgen -W "${MODULEPATH}" -- "${cur}") )
       ;;
     use|*-a*)
-      _filedir -d 2>/dev/null || _module_filedir
+      _module_dir "${cur}"
       ;;
     help|show|whatis)
       COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
@@ -188,27 +236,27 @@ _ml() {
       case "${cur}" in
         -*)
           if [ ${COMP_CWORD} -eq 1 ]; then
-              COMPREPLY=( $(compgen -W "${opts} $(_module_loaded_modules_negated)" -- "${cur}") )
+            COMPREPLY=( $(compgen -W "${opts} $(_module_loaded_modules_negated)" -- "${cur}") )
           else
             COMPREPLY=( $(compgen -W "        $(_module_loaded_modules_negated)" -- "${cur}") )
           fi
           ;;
         *)
           if [ ${COMP_CWORD} -eq 1 ]; then
-              case "${cur}" in
-                ls)
-                  COMPREPLY='list'
-                  ;;
-                sw*)
-                  COMPREPLY='swap'
-                  ;;
-                *)
-                  COMPREPLY=( $(compgen -W "${cmds} $(_module_avail)" -- "${cur}") )
-                  ;;
-              esac
+            case "${cur}" in
+              ls)
+                COMPREPLY='list'
+                ;;
+              sw*)
+                COMPREPLY='swap'
+                ;;
+              *)
+                COMPREPLY=( $(compgen -W "${cmds} $(_module_avail)" -- "${cur}") )
+                ;;
+            esac
           else
             if [[ ${COMP_WORDS[COMP_CWORD-2]} == sw* ]]; then
-                COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
+              COMPREPLY=( $(compgen -W "$(_module_not_yet_loaded)" -- "${cur}") )
             else
               for ((i = COMP_CWORD - 1; i > 0; i--)); do
                 case ${COMP_WORDS[$i]} in
@@ -230,7 +278,7 @@ _ml() {
                 esac
               done
               if [ -z "${found}" ]; then
-                  COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
+                COMPREPLY=( $(compgen -W "$(_module_avail)" -- "${cur}") )
               fi
             fi
           fi
@@ -243,4 +291,7 @@ complete -F _ml ml
 # Local Variables:
 # mode: shell-script
 # indent-tabs-mode: nil
+# sh-basic-offset: 2
+# sh-indent-comment: t
 # End:
+# ex: ts=2 sw=2 et filetype=sh


### PR DESCRIPTION
* Renamed `_module_filedir` function to `_module_dir` as it only handles dirs and not files.
* Added support for environment variables to _module_dir, so they can be used in `ml use` and `module use` commands.
 * Autocompleted environment variables are filtered for ones that contain existing directory paths, so you will only get relevant autocomplete suggestions.
* Added support for `~` to _module_dir, so we can expand to the user's home dir in `ml use` and `module use` commands.
* Fixed mis-indentation after `if`, where 4 spaces per indentation level were used whereas all other lines used only 2.
* Completely removed the dependency on `_filedir` function from the bash_completion package: the custom `_module_dir` function is now more advanced than the standard `_filedir` and no longer the fall-back.