### PR TITLE
Add a --config-json option

### DIFF
--- a/rt/help/err.txt
+++ b/rt/help/err.txt
@@ -34,6 +34,7 @@ Options:
   --localvar=localvarA              local variables needed to be set after this commands execution
   --check_syntax --checkSyntax      Checking module command syntax: do not load
   --config                          Report Lmod Configuration
+  --config-json                     Report Lmod Configuration in json format
   --mt                              Report Module Table State
   --timer                           report run times
   --force                           force removal of a sticky module or save an empty collection
@@ -128,6 +129,7 @@ Options:
   --localvar=localvarA              local variables needed to be set after this commands execution
   --check_syntax --checkSyntax      Checking module command syntax: do not load
   --config                          Report Lmod Configuration
+  --config-json                     Report Lmod Configuration in json format
   --mt                              Report Module Table State
   --timer                           report run times
   --force                           force removal of a sticky module or save an empty collection

--- a/src/Options.lua
+++ b/src/Options.lua
@@ -281,6 +281,13 @@ function M.options(self, usage)
    }
 
    cmdlineParser:add_option{
+      name   = {"--config-json" },
+      dest   = "configjson",
+      action = "store_true",
+      help   = "Report Lmod Configuration in json format",
+   }
+
+   cmdlineParser:add_option{
       name   = {"--mt" },
       dest   = "reportMT",
       action = "store_true",

--- a/src/lmod.in.lua
+++ b/src/lmod.in.lua
@@ -421,7 +421,7 @@ function main()
       {'^up'      , updateTbl     },
       {'^use$'    , useTbl        },
       {'^w'       , whatisTbl     },
-   }  
+   }
 
    MCP = MasterControl.build("load")
    mcp = MasterControl.build("load")
@@ -534,6 +534,15 @@ function main()
       os.exit(0)
    end
 
+   -- dump Configuration in json and quit.
+   if (masterTbl.configjson) then
+      local Configuration = require("Configuration")
+      local configuration = Configuration:configuration()
+      local a = configuration:report_json()
+      io.stderr:write(a)
+      os.exit(0)
+   end
+
    ------------------------------------------------------------
    -- Search for command, quit if command is unknown.
    local cmdT = false
@@ -545,7 +554,7 @@ function main()
          end
       end
    end
-   
+
    ------------------------------------------------------------
    -- Must output local variables even when there is the command
    -- is not a valid command

--- a/src/ml_cmd.in.lua
+++ b/src/ml_cmd.in.lua
@@ -75,7 +75,7 @@ if (ia) then
 end
 
 package.path  = LuaCommandName_dir .. "../tools/?.lua;" ..
-                LuaCommandName_dir .. "?.lua;"          .. 
+                LuaCommandName_dir .. "?.lua;"          ..
                 sys_lua_path
 package.cpath = sys_lua_cpath
 
@@ -156,6 +156,7 @@ function main()
       ["--timer"] = 0,
       ["--version"]=0,  ["--versoin"]=0, ["--ver"]=0, ["--v"]=0, ["-v"]=0,
       ['--config'] = 0,
+      ['--config-json'] = 0,
       ['--raw'] = 0,
       ['--regexp'] = 0, ['-r'] = 0,
       ['--show_hidden'] = 0, ['--show-hidden'] = 0,


### PR DESCRIPTION
This option will dump the current Lmod configuation as json to stderr.
It contains the same information as --config.

```
$ ml --config-json 2>&1| python -mjson.tool
{
    "cache": [
        [
            "/apps/gent/lmodcache",
            "/apps/gent/lmodcache/timestamp"
        ]
    ],
    "config": {
        "allowTCL": "yes",
        "autoSwap": "no",
        "case": "yes",
        "colorize": "yes",
        "disable1N": "yes",
        "dot_files": "yes",
        "dupPaths": "no",
        "exactMatch": "no",
        "expMCmd": "YES",
        "ld_lib_path": "<empty>",
        "ld_preload": "<empty>",
        "lmodV": "6.5.17-1-gfe3b4b6",
        "luaV": "Lua 5.3",
        "lua_json": "yes",
        "lua_term": "yes",
        "lua_term_A": "true",
        "modRC": "/home/ward/tmp/Lmod/install/lmod/etc/rc",
        "mpath_av": "no",
        "mpath_root": "/etc/modulefiles/vsc",
        "numSC": 1,
        "ordering": "modern",
        "pager": "/usr/bin/less",
        "pager_opts": "-XqMREF",
        "path_hash": "/usr/bin/sha1sum",
        "path_lua": "/usr/bin",
        "pin_v": "yes",
        "pkg": "Pkg",
        "prefix": "/home/ward/tmp/Lmod/install",
        "prpnd_blk": "normal",
        "redirect": "yes",
        "settarg": "no",
        "sitePkg": "standard",
        "spdr_ignore": "no",
        "spdr_loads": "no",
        "tm_ancient": "86400",
        "tm_short": "86400",
        "tm_threshold": 1,
        "tmod_rule": "no",
        "uname": "Linux weedly.ugent.be 4.7.5-200.fc24.x86_64 #1 SMP Mon Sep 26 21:25:47 UTC 2016 x86_64 x86_64 x86_64 GNU/Linux\n",
        "z01_admin": "/home/ward/tmp/Lmod/install/lmod/etc/admin.list",
        "z02_admin": "no",
        "z03_cv": "no"
    },
    "propt": {
        "arch": {
            "displayT": {
                "gpu": {
                    "color": "red",
                    "doc": "built for GPU",
                    "long": "(g)",
                    "short": "(g)"
                },
                "gpu:mic": {
                    "color": "red",
                    "doc": "built natively for MIC and GPU",
                    "long": "(g,m)",
                    "short": "(gm)"
                },
                "gpu:mic:offload": {
                    "color": "red",
                    "doc": "built natively for MIC and GPU and offload to the MIC",
                    "long": "(g,m,o)",
                    "short": "(@)"
                },
                "mic": {
                    "color": "blue",
                    "doc": "built for host and native MIC",
                    "long": "(m)",
                    "short": "(m)"
                },
                "mic:offload": {
                    "color": "blue",
                    "doc": "built for host, native MIC and offload to the MIC",
                    "long": "(m,o)",
                    "short": "(*)"
                },
                "offload": {
                    "color": "blue",
                    "doc": "built for offload to the MIC only",
                    "long": "(o)",
                    "short": "(o)"
                }
            },
            "validT": {
                "gpu": 1,
                "mic": 1,
                "offload": 1
            }
        },
        "lmod": {
            "displayT": {
                "sticky": {
                    "color": "red",
                    "doc": "Module is Sticky, requires --force to unload or purge",
                    "long": "(S)",
                    "short": "(S)"
                }
            },
            "validT": {
                "sticky": 1
            }
        },
        "state": {
            "displayT": {
                "experimental": {
                    "color": "blue",
                    "doc": "Experimental",
                    "long": "(E)",
                    "short": "(E)"
                },
                "obsolete": {
                    "color": "red",
                    "doc": "Obsolete",
                    "long": "(O)",
                    "short": "(O)"
                },
                "testing": {
                    "color": "green",
                    "doc": "Testing",
                    "long": "(T)",
                    "short": "(T)"
                }
            },
            "validT": {
                "experimental": 1,
                "obsolete": 1,
                "testing": 1
            }
        },
        "status": {
            "displayT": {
                "active": {
                    "color": "yellow",
                    "doc": "Module is loaded",
                    "long": "(L)",
                    "short": "(L)"
                }
            },
            "validT": {
                "active": 1
            }
        }
    },
    "rcfiles": [
        "/home/ward/tmp/Lmod/install/lmod/6.5.17/init/lmodrc.lua",
        "/home/ward/tmp/Lmod/lmodrc.lua"
    ]
}
```