### PR TITLE
Enable R testing on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # although Lmod is written in Lua, use Python environment
 language: python
-sudo: false
+sudo: required
 
 env:
   - LUA='lua=5.1'
@@ -23,6 +23,11 @@ before_install:
   - git clone https://github.com/rtmclay/Hermes.git
   - export PATH="$PATH:$PWD/lua_install/bin:$HOME/Hermes/bin"
   - cd -
+  - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
+  # add our launchpad repo which has (inter alia) r-cran-rcmdcheck
+  - sudo add-apt-repository -y ppa:edd/misc
+  - ./run.sh bootstrap
+  - which Rscript
 
 install:
   - luarocks install luaposix

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 # although Lmod is written in Lua, use Python environment
 language: python
-sudo: required
+sudo: false
 
 env:
   - LUA='lua=5.1'
@@ -13,6 +13,7 @@ addons:
       - tcsh
       - tcl8.5
       - uuid  # for uuidgen
+      - r-base
 
 before_install:
   - cd $HOME
@@ -23,10 +24,6 @@ before_install:
   - git clone https://github.com/rtmclay/Hermes.git
   - export PATH="$PATH:$PWD/lua_install/bin:$HOME/Hermes/bin"
   - cd -
-  - curl -OLs http://eddelbuettel.github.io/r-travis/run.sh && chmod 0755 run.sh
-  # add our launchpad repo which has (inter alia) r-cran-rcmdcheck
-  - sudo add-apt-repository -y ppa:edd/misc
-  - ./run.sh bootstrap
   - which Rscript
 
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,6 @@ before_install:
   - git clone https://github.com/rtmclay/Hermes.git
   - export PATH="$PATH:$PWD/lua_install/bin:$HOME/Hermes/bin"
   - cd -
-  - which Rscript
 
 install:
   - luarocks install luaposix

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,8 @@ env:
 
 addons:
   apt:
+    sources:
+      - r-packages-precise
     packages:
       - tcsh
       - tcl8.5

--- a/init/r.in
+++ b/init/r.in
@@ -3,7 +3,7 @@ module <- function(...){
   arglist <- as.list(match.call())
   ## change this from 'module' to 'r'
   arglist[1] <- 'r'
-  args <- paste0(arglist, collapse = ' ')
+  args <- paste(arglist, collapse = ' ', sep = '')
 
   binary <- "@PKG@/libexec/lmod"
 

--- a/rt/R/R.tdesc
+++ b/rt/R/R.tdesc
@@ -32,7 +32,7 @@ source("$(outputDir)/init/r")
 
 module("load foobar")
 
-cat('FOOBAR:', Sys.getenv('FOOBAR'))
+cat('FOOBAR:', Sys.getenv('FOOBAR'), "\n")
 
 module("avail")
 EOF

--- a/rt/R/R.tdesc
+++ b/rt/R/R.tdesc
@@ -8,7 +8,7 @@ testdescript = {
    ]],
    keywords = {"rscript" },
 
-   active = false;
+   active = 1;
    testName = "rscript",
    job_submit_method = "INTERACTIVE",
 
@@ -18,7 +18,6 @@ testdescript = {
 
      unsetMT
      initStdEnvVars
-     PATH=$(PATH):/usr/local/bin
      MODULEPATH_ROOT=$(testDir)/mf;     export MODULEPATH_ROOT
      MODULEPATH="$(testDir)/mf/Core";   export MODULEPATH
 

--- a/rt/R/err.txt
+++ b/rt/R/err.txt
@@ -1,4 +1,4 @@
-ProjectDIR/rt/r/mf/Core
+ProjectDIR/rt/R/mf/Core
    foobar/1.0 (L)
   Where:
    L:  Module is loaded


### PR DESCRIPTION
@wpoely86 was correct. This PR augments `.travis.yml` to install R on travis and enables the test for R as an output shell.