### PR TITLE
TERM can be set with an empty value which results in a tput error

### DIFF
--- a/tools/TermWidth.lua
+++ b/tools/TermWidth.lua
@@ -62,7 +62,7 @@ local function askSystem(width)
    end
 
    -- Try tput cols
-   if (getenv("TERM")) then
+   if (getenv("TERM") and not getenv("TERM") == '') then
       local result  = capture("tput cols")
       i, j, columns = result:find("^(%d+)")
       if (i) then


### PR DESCRIPTION
When term is set to an empty string tput prints an error message on our cluster:

 ```tput: No value for $TERM and no -T specified```