### PR TITLE
expanded German translation

### DIFF
--- a/messageDir/de.lua
+++ b/messageDir/de.lua
@@ -4,8 +4,75 @@ return {
      --------------------------------------------------------------------------
      -- LmodError messages
      --------------------------------------------------------------------------
-     e110 = "Das Kommando 'module avail' kann nicht ausgefuehrt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthaelt einen ungueltigen Wert",
-     e113 = "Das Modul  \"%{name}\" kann ohne diese Module nicht geladen werden:\n   %{module_list}\n",
-     e119 = "Der Name einer Modulsammlung darf keinen Punkt `.' enthalten.\n  Bitte geben Sie der Sammlung  \"%{collection}\" einen neuen Namen.\n",
+     e101 = "Kein Programm zum Bestimmen von Hashwerten verfügbar (sha1sum, shasum, md5sum oder md5)",
+     e102 = "Nicht einlesbar: \"%{path}\". Abbruch!\n",
+     e103 = "Fehler in LocationT:search()",
+     e104 = "%{routine}: Kein Modul für \"%{name}\" gefunden. Das sollte nicht passieren!\n",
+     e105 = "%{routine}: Systemeinstellungs-Tabelle enthält keine %{location} für: \"%{name}\". \nÜberprüfen Sie die Schreibweise des Namens.\n",
+     e106 = "%{routine}: Die validT-Tabelle für %{name} hat keinen Eintrag für: \"%{value}\". \nÜberprüfen Sie die Schreibweise des Namens.\n",
+     e107 = "Nicht auffindbar: \"%{name}\"\n",
+     e108 = "Fehler bei der Vererbung: %{name}\n",
+     e109 = [==[Die Einstellungen verhindern den automatischen Austausch von Modulen mit gleichen Namen. Die geladene Version von "%{oldFullName}" muss entladen werden, bevor eine andere Version geladen werden kann. Verwenden Sie dafür swap wie folgt:
+
+   $ module swap %{oldFullName} %{newFullName}
+
+Alternativ können Sie die Umgebungsvariable LMOD_DISABLE_SAME_NAME_AUTOSWAP auf "no" setzen, um den automatischen Austausch von Modulen zu aktivieren.
+]==],
+     e110 = "Das Kommando 'module avail' kann nicht ausgeführt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthält einen ungültigen Wert",
+     e111 = "%{func}(\"%{name}\") ist ungültig, es wird ein Wert benötigt",
+     e112 = "Das Modul \"%{name}\" kann nicht geladen werden, weil diese Module geladen sind:\n   %{module_list}\n",
+     e113 = "Das Modul \"%{name}\" kann ohne diese Module nicht geladen werden:\n   %{module_list}\n",
+     e114 = "Das Modul \"%{name}\" kann nicht geladen werden. Mindestens eines dieser Module muss geladen sein:\n   %{module_list}\n",
+     e115 = [==[Nur ein Modul von %{name} kann gleichzeitig geladen sein.
+Es ist bereits %{oldName} geladen.
+Verwende folgendes Kommando, um das Modul zu laden:
+
+  $  module swap %{oldName} %{fullName}
+
+Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
+]==],
+     e116 = "Unbekannter Schlüssel: \"%{key}\" in setStandardPaths\n",
+     e117 = "Keine passenden Module gefunden\n",
+     e118 = "Benutzer-Modulsammlung: \"%{collection}\" existiert nicht.\n  \"module savelist\" zeigt mögliche Werte.\n",
+     e119 = "Der Name einer Modulsammlung darf kein `.' enthalten.\n  Bitte geben Sie der Sammlung  \"%{collection}\" einen neuen Namen.\n",
+     e120 = "Swap fehlgeschlagen: \"%{name}\" ist nicht geladen.\n",
+     e121 = "Modul konnte nicht geladen werden: %{name}\n     %{fn}: %{message}\n",
+     e122 = "sandbox_registration: Das übergebene Argument ist vom Typ: \"%{kind}\". Es sollte eine Liste sein.",
+     e123 = "uuidgen ist nicht verfügbar, Alternative ist ebenfalls fehlgeschlagen",
+     e124 = "Zeitbegrenzung für Spider-Suche ist abgelaufen\n",
+     e125 = "dbT[sn] schlug fehl für sn: %{sn}\n",
+     e126 = "Hashwert konnte nicht berechnet werden\n",
+
+     --------------------------------------------------------------------------
+     -- LmodMessages
+     --------------------------------------------------------------------------
+     m401 = "\nLmod hat \"%{oldFullName}\" automatisch durch \"%{newFullName}\" ersetzt\n",
+
+     --------------------------------------------------------------------------
+     -- LmodWarnings
+     --------------------------------------------------------------------------
+     w501 = [==[Ein oder mehrere Module in ihrer Sammlung %{collectionName} wurden geändert: "%{module_list}".
+Um die Inhalte der Sammlung anzuzeigen, verwenden Sie:
+  $ module describe %{collectionName}
+Um die Sammlung neu anzulegen, laden Sie zuerst die gewünschten Module und führen Sie danach folgendes aus:
+  $ module save %{collectionName}
+Falls sie die Modulsammlung löschen möchten, verwenden sie:
+  $ rm ~/.lmod.d/%{collectionName}
+
+Weitere Informationen finden mit 'module help' oder unter http://lmod.readthedocs.org/
+Die geladenen Module wurden nicht verändert
+
+]==],
+     w502 = "Fehler in der Zeile module-version: module-name muss vollqualifiziert sein: %{fullName} ist dies nicht\n",
+     w503 = "MODULEPATH des Systems hat sich geändert: Bitte legen Sie ihre gespeicherten Sammlungen neu an.\n",
+     w504 = "Sie haben keine Module geladen, weil die Sammlung \"%{collectionName}\" leer ist!\n",
+     w505 = "Die folgenden Module wurden nicht geladen: %{module_list}\n\n",
+     w506 = "Keine Sammlung mit dem Namen \"%{collection}\" gefunden.",
+     w507 = "MODULEPATH ist nicht definiert\n",
+     w508 = "Der Name einer Sammlung darf kein `.' enthalten. Bitte vergeben Sie einen anderen Namen für: %{name}",
+     w509 = "Die Bezeichnung 'system' für Sammlungen ist reserviert. Bitte vergeben Sie einen anderen Namen.\n",
+     w510 = [==[Sie versuchen in "%{name}" eine leere Modulsammlung zu speichern. Falls Sie dies wollen, verwenden sie:
+  $  module --force save %{name}
+]==],
    }
 }

--- a/messageDir/de.lua
+++ b/messageDir/de.lua
@@ -18,26 +18,26 @@ return {
      e108 = "Fehler bei der Vererbung: %{name}\n",
      e109 = [==[Die Einstellungen verhindern den automatischen Austausch von Modulen mit gleichen Namen. Die geladene Version von "%{oldFullName}" muss entladen werden, bevor eine andere Version geladen werden kann. Verwenden Sie dafür swap wie folgt:
 
-   $ module swap %{oldFullName} %{newFullName}
+  $ module swap %{oldFullName} %{newFullName}
 
 Alternativ können Sie die Umgebungsvariable LMOD_DISABLE_SAME_NAME_AUTOSWAP auf "no" setzen, um den automatischen Austausch von Modulen zu aktivieren.
 ]==],
      e110 = "Das Kommando 'module avail' kann nicht ausgeführt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthält einen ungültigen Wert",
      e111 = "%{func}(\"%{name}\") ist ungültig, es wird ein Wert benötigt",
      e112 = [==[Das Modul "%{name}" kann nicht geladen werden, weil diese Module geladen sind:
-   %{module_list}
+  %{module_list}
 ]==],
      e113 = [==[Das Modul "%{name}" kann ohne diese Module nicht geladen werden:
-   %{module_list}
+  %{module_list}
 ]==],
      e114 = [==[Das Modul "%{name}" kann nicht geladen werden. Mindestens eines dieser Module muss geladen sein:
-   %{module_list}
+  %{module_list}
 ]==],
      e115 = [==[Nur ein Modul von %{name} kann gleichzeitig geladen sein.
 Es ist bereits %{oldName} geladen.
 Verwende folgendes Kommando, um das Modul zu laden:
 
-  $  module swap %{oldName} %{fullName}
+  $ module swap %{oldName} %{fullName}
 
 Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
 ]==],
@@ -47,7 +47,7 @@ Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
   "module savelist" zeigt mögliche Werte.
 ]==],
      e119 = [==[Der Name einer Modulsammlung darf kein `.' enthalten.
-  Bitte geben Sie der Sammlung  "%{collection}" einen neuen Namen.
+  Bitte geben Sie der Sammlung "%{collection}" einen neuen Namen.
 ]==],
      e120 = "Swap fehlgeschlagen: \"%{name}\" ist nicht geladen.\n",
      e121 = [==[Modul konnte nicht geladen werden: %{name}
@@ -88,7 +88,7 @@ Die geladenen Module wurden nicht verändert
      w508 = "Der Name einer Sammlung darf kein `.' enthalten. Bitte vergeben Sie einen anderen Namen für: %{name}",
      w509 = "Die Bezeichnung 'system' für Sammlungen ist reserviert. Bitte vergeben Sie einen anderen Namen.\n",
      w510 = [==[Sie versuchen in "%{name}" eine leere Modulsammlung zu speichern. Falls Sie dies wollen, verwenden sie:
-  $  module --force save %{name}
+  $ module --force save %{name}
 ]==],
    }
 }

--- a/messageDir/de.lua
+++ b/messageDir/de.lua
@@ -72,7 +72,7 @@ Um die Inhalte der Sammlung anzuzeigen, verwenden Sie:
   $ module describe %{collectionName}
 Um die Sammlung neu anzulegen, laden Sie zuerst die gewünschten Module und führen Sie danach folgendes aus:
   $ module save %{collectionName}
-Falls sie die Modulsammlung löschen möchten, verwenden sie:
+Falls Sie die Modulsammlung löschen möchten, verwenden Sie:
   $ rm ~/.lmod.d/%{collectionName}
 
 Weitere Informationen finden Sie mit 'module help' oder unter http://lmod.readthedocs.org/.

--- a/messageDir/de.lua
+++ b/messageDir/de.lua
@@ -4,9 +4,9 @@ return {
      --------------------------------------------------------------------------
      -- LmodError messages
      --------------------------------------------------------------------------
-     e101 = "Kein Programm zum Bestimmen von Hashwerten verfügbar (sha1sum, shasum, md5sum oder md5)",
+     e101 = "Kein Programm zum Bestimmen von Hashwerten verfügbar (sha1sum, shasum, md5sum oder md5).",
      e102 = "Nicht einlesbar: \"%{path}\". Abbruch!\n",
-     e103 = "Fehler in LocationT:search()",
+     e103 = "Fehler in LocationT:search().",
      e104 = "%{routine}: Kein Modul für \"%{name}\" gefunden. Das sollte nicht passieren!\n",
      e105 = [==[%{routine}: Systemeinstellungs-Tabelle enthält keine %{location} für: "%{name}".
 Überprüfen Sie die Schreibweise des Namens.
@@ -14,16 +14,16 @@ return {
      e106 = [==[%{routine}: Die validT-Tabelle für %{name} hat keinen Eintrag für: "%{value}".
 Überprüfen Sie die Schreibweise des Namens.
 ]==],
-     e107 = "Nicht auffindbar: \"%{name}\"\n",
-     e108 = "Fehler bei der Vererbung: %{name}\n",
+     e107 = "Nicht auffindbar: \"%{name}\".\n",
+     e108 = "Fehler bei der Vererbung: %{name}.\n",
      e109 = [==[Die Einstellungen verhindern den automatischen Austausch von Modulen mit gleichen Namen. Die geladene Version von "%{oldFullName}" muss entladen werden, bevor eine andere Version geladen werden kann. Verwenden Sie dafür swap wie folgt:
 
   $ module swap %{oldFullName} %{newFullName}
 
 Alternativ können Sie die Umgebungsvariable LMOD_DISABLE_SAME_NAME_AUTOSWAP auf "no" setzen, um den automatischen Austausch von Modulen zu aktivieren.
 ]==],
-     e110 = "Das Kommando 'module avail' kann nicht ausgeführt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthält einen ungültigen Wert",
-     e111 = "%{func}(\"%{name}\") ist ungültig, es wird ein Wert benötigt",
+     e110 = "Das Kommando 'module avail' kann nicht ausgeführt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthält einen ungültigen Wert.",
+     e111 = "%{func}(\"%{name}\") ist ungültig, es wird ein Wert benötigt.",
      e112 = [==[Das Modul "%{name}" kann nicht geladen werden, weil diese Module geladen sind:
   %{module_list}
 ]==],
@@ -41,8 +41,8 @@ Verwende folgendes Kommando, um das Modul zu laden:
 
 Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
 ]==],
-     e116 = "Unbekannter Schlüssel: \"%{key}\" in setStandardPaths\n",
-     e117 = "Keine passenden Module gefunden\n",
+     e116 = "Unbekannter Schlüssel: \"%{key}\" in setStandardPaths.\n",
+     e117 = "Keine passenden Module gefunden.\n",
      e118 = [==[Benutzer-Modulsammlung: "%{collection}" existiert nicht.
   "module savelist" zeigt mögliche Werte.
 ]==],
@@ -54,15 +54,15 @@ Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
      %{fn}: %{message}
 ]==],
      e122 = "sandbox_registration: Das übergebene Argument ist vom Typ: \"%{kind}\". Es sollte eine Liste sein.",
-     e123 = "uuidgen ist nicht verfügbar, Alternative ist ebenfalls fehlgeschlagen",
-     e124 = "Zeitbegrenzung für Spider-Suche ist abgelaufen\n",
-     e125 = "dbT[sn] schlug fehl für sn: %{sn}\n",
-     e126 = "Hashwert konnte nicht berechnet werden\n",
+     e123 = "uuidgen ist nicht verfügbar, Alternative ist ebenfalls fehlgeschlagen.",
+     e124 = "Zeitbegrenzung für Spider-Suche ist abgelaufen.\n",
+     e125 = "dbT[sn] schlug fehl für sn: %{sn}.\n",
+     e126 = "Hashwert konnte nicht berechnet werden.\n",
 
      --------------------------------------------------------------------------
      -- LmodMessages
      --------------------------------------------------------------------------
-     m401 = "\nLmod hat \"%{oldFullName}\" automatisch durch \"%{newFullName}\" ersetzt\n",
+     m401 = "\nLmod hat \"%{oldFullName}\" automatisch durch \"%{newFullName}\" ersetzt.\n",
 
      --------------------------------------------------------------------------
      -- LmodWarnings
@@ -75,19 +75,19 @@ Um die Sammlung neu anzulegen, laden Sie zuerst die gewünschten Module und füh
 Falls sie die Modulsammlung löschen möchten, verwenden sie:
   $ rm ~/.lmod.d/%{collectionName}
 
-Weitere Informationen finden mit 'module help' oder unter http://lmod.readthedocs.org/
-Die geladenen Module wurden nicht verändert
+Weitere Informationen finden Sie mit 'module help' oder unter http://lmod.readthedocs.org/.
+Die geladenen Module wurden nicht verändert.
 
 ]==],
-     w502 = "Fehler in der Zeile module-version: module-name muss vollqualifiziert sein: %{fullName} ist dies nicht\n",
+     w502 = "Fehler in der Zeile module-version: module-name muss vollqualifiziert sein: %{fullName} ist dies nicht.\n",
      w503 = "MODULEPATH des Systems hat sich geändert: Bitte legen Sie ihre gespeicherten Sammlungen neu an.\n",
      w504 = "Sie haben keine Module geladen, weil die Sammlung \"%{collectionName}\" leer ist!\n",
-     w505 = "Die folgenden Module wurden nicht geladen: %{module_list}\n\n",
+     w505 = "Die folgenden Module wurden nicht geladen: %{module_list}.\n\n",
      w506 = "Keine Sammlung mit dem Namen \"%{collection}\" gefunden.",
-     w507 = "MODULEPATH ist nicht definiert\n",
-     w508 = "Der Name einer Sammlung darf kein `.' enthalten. Bitte vergeben Sie einen anderen Namen für: %{name}",
+     w507 = "MODULEPATH ist nicht definiert.\n",
+     w508 = "Der Name einer Sammlung darf kein `.' enthalten. Bitte vergeben Sie einen anderen Namen für: %{name}.",
      w509 = "Die Bezeichnung 'system' für Sammlungen ist reserviert. Bitte vergeben Sie einen anderen Namen.\n",
-     w510 = [==[Sie versuchen in "%{name}" eine leere Modulsammlung zu speichern. Falls Sie dies wollen, verwenden sie:
+     w510 = [==[Sie versuchen in "%{name}" eine leere Modulsammlung zu speichern. Falls Sie dies wollen, verwenden Sie:
   $ module --force save %{name}
 ]==],
    }

--- a/messageDir/de.lua
+++ b/messageDir/de.lua
@@ -8,8 +8,12 @@ return {
      e102 = "Nicht einlesbar: \"%{path}\". Abbruch!\n",
      e103 = "Fehler in LocationT:search()",
      e104 = "%{routine}: Kein Modul für \"%{name}\" gefunden. Das sollte nicht passieren!\n",
-     e105 = "%{routine}: Systemeinstellungs-Tabelle enthält keine %{location} für: \"%{name}\". \nÜberprüfen Sie die Schreibweise des Namens.\n",
-     e106 = "%{routine}: Die validT-Tabelle für %{name} hat keinen Eintrag für: \"%{value}\". \nÜberprüfen Sie die Schreibweise des Namens.\n",
+     e105 = [==[%{routine}: Systemeinstellungs-Tabelle enthält keine %{location} für: "%{name}".
+Überprüfen Sie die Schreibweise des Namens.
+]==],
+     e106 = [==[%{routine}: Die validT-Tabelle für %{name} hat keinen Eintrag für: "%{value}".
+Überprüfen Sie die Schreibweise des Namens.
+]==],
      e107 = "Nicht auffindbar: \"%{name}\"\n",
      e108 = "Fehler bei der Vererbung: %{name}\n",
      e109 = [==[Die Einstellungen verhindern den automatischen Austausch von Modulen mit gleichen Namen. Die geladene Version von "%{oldFullName}" muss entladen werden, bevor eine andere Version geladen werden kann. Verwenden Sie dafür swap wie folgt:
@@ -20,9 +24,15 @@ Alternativ können Sie die Umgebungsvariable LMOD_DISABLE_SAME_NAME_AUTOSWAP auf
 ]==],
      e110 = "Das Kommando 'module avail' kann nicht ausgeführt werden. Die Variable MODULEPATH ist entweder nicht gesetzt oder enthält einen ungültigen Wert",
      e111 = "%{func}(\"%{name}\") ist ungültig, es wird ein Wert benötigt",
-     e112 = "Das Modul \"%{name}\" kann nicht geladen werden, weil diese Module geladen sind:\n   %{module_list}\n",
-     e113 = "Das Modul \"%{name}\" kann ohne diese Module nicht geladen werden:\n   %{module_list}\n",
-     e114 = "Das Modul \"%{name}\" kann nicht geladen werden. Mindestens eines dieser Module muss geladen sein:\n   %{module_list}\n",
+     e112 = [==[Das Modul "%{name}" kann nicht geladen werden, weil diese Module geladen sind:
+   %{module_list}
+]==],
+     e113 = [==[Das Modul "%{name}" kann ohne diese Module nicht geladen werden:
+   %{module_list}
+]==],
+     e114 = [==[Das Modul "%{name}" kann nicht geladen werden. Mindestens eines dieser Module muss geladen sein:
+   %{module_list}
+]==],
      e115 = [==[Nur ein Modul von %{name} kann gleichzeitig geladen sein.
 Es ist bereits %{oldName} geladen.
 Verwende folgendes Kommando, um das Modul zu laden:
@@ -33,10 +43,16 @@ Falls Sie weitere Unterstützung brauchen, erstellen Sie ein Support-Ticket.
 ]==],
      e116 = "Unbekannter Schlüssel: \"%{key}\" in setStandardPaths\n",
      e117 = "Keine passenden Module gefunden\n",
-     e118 = "Benutzer-Modulsammlung: \"%{collection}\" existiert nicht.\n  \"module savelist\" zeigt mögliche Werte.\n",
-     e119 = "Der Name einer Modulsammlung darf kein `.' enthalten.\n  Bitte geben Sie der Sammlung  \"%{collection}\" einen neuen Namen.\n",
+     e118 = [==[Benutzer-Modulsammlung: "%{collection}" existiert nicht.
+  "module savelist" zeigt mögliche Werte.
+]==],
+     e119 = [==[Der Name einer Modulsammlung darf kein `.' enthalten.
+  Bitte geben Sie der Sammlung  "%{collection}" einen neuen Namen.
+]==],
      e120 = "Swap fehlgeschlagen: \"%{name}\" ist nicht geladen.\n",
-     e121 = "Modul konnte nicht geladen werden: %{name}\n     %{fn}: %{message}\n",
+     e121 = [==[Modul konnte nicht geladen werden: %{name}
+     %{fn}: %{message}
+]==],
      e122 = "sandbox_registration: Das übergebene Argument ist vom Typ: \"%{kind}\". Es sollte eine Liste sein.",
      e123 = "uuidgen ist nicht verfügbar, Alternative ist ebenfalls fehlgeschlagen",
      e124 = "Zeitbegrenzung für Spider-Suche ist abgelaufen\n",


### PR DESCRIPTION
This adds all the messages currently defined in messageDir/en.lua in German.

Is there a reason for multiple consecutive spaces (e. g. before variables in strings and after punctuation), for missing punctuation at the end of messages, and different formatting of multiline text? For now I mimicked the English translation.

Are non-ASCII characters allowed (especially ä/ö/ü/ß)? The previous German translation used ae/oe/... for these.

@wookietreiber: could you also take a look at this?