### PR TITLE
Added missing errWarnMsgHook in the documentation

### DIFF
--- a/docs/source/170_hooks.rst
+++ b/docs/source/170_hooks.rst
@@ -78,7 +78,10 @@ Hook functions
   family prefix:  ``site_FAMILY_``
 
 **msgHook**(...):
-  Hook to print messages after avail, list, spider, LmodError and LmodWarning.
+  Hook to print messages after avail, list, spider
+
+**errWarnMsgHook**(...):
+  Hook to print messages after LmodError, LmodWarning, LmodMessage
 
 **groupName**(...):
   This hook adds the arch and os name to moduleT.lua to make it safe


### PR DESCRIPTION
A new hook errWarnMsgHook is not documented. Since it might break most of the SitePackage.lua instances it's good to document it ASAP.