### PR TITLE
Extend the errWarnMsgHook to also pass the keys of the message

### DIFF
--- a/src/MasterControl.lua
+++ b/src/MasterControl.lua
@@ -582,7 +582,7 @@ local function l_generateMsg(kind, label, ...)
       local t   = arg[1]
       local key = t.msg
       local msg = i18n(key, t)
-      msg       = hook.apply("errWarnMsgHook", kind, key, msg) or msg
+      msg       = hook.apply("errWarnMsgHook", kind, key, msg, t) or msg
       sA[#sA+1] = buildMsg(twidth, label, msg)
    else
       sA[#sA+1] = buildMsg(twidth, label, ...)
@@ -604,7 +604,7 @@ function M.message(self, ...)
       local t   = arg[1]
       local key = t.msg
       local msg = i18n(key, t)
-      msg       = hook.apply("errWarnMsgHook", "lmodmessage", key, msg) or msg
+      msg       = hook.apply("errWarnMsgHook", "lmodmessage", key, msg, t) or msg
       sA[#sA+1] = buildMsg(twidth, msg)
    else
       sA[#sA+1] = buildMsg(twidth, ...)


### PR DESCRIPTION
A message gets composed from the string in messageT.lua and the keys
that are passed. Before, the hook only got the fully composed message.
With this commit, we pass both the full message and the keys used to
compose it. This gives you a bit more flexibility. 

You can now adjust the message the user sees and use logic based on
the 'input' (the keys).

But it of course breaks existing errWarnMsgHooks...