### PR TITLE
pushenv, setenv and unsetenv now check if MODULEPATH has changed

### DIFF
--- a/src/MT.lua
+++ b/src/MT.lua
@@ -635,6 +635,8 @@ function M.updateMPathA(self, value)
       self.mpathA = path2pathA(value)
    elseif (type(value) == "table") then
       self.mpathA = value
+   elseif (type(value) == "nil") then
+      self.mpathA = path2pathA("")
    end
 end
 

--- a/src/Var.lua
+++ b/src/Var.lua
@@ -156,7 +156,6 @@ end
 -- @param value The value assigned to the variable.
 -- @param sep The separator character.  (By default it is ":")
 function M.new(self, name, value, sep)
-   local adding = true
    local o = {}
    setmetatable(o,self)
    self.__index = self

--- a/src/Var.lua
+++ b/src/Var.lua
@@ -166,7 +166,6 @@ function M.new(self, name, value, sep)
    extract(o)
    if (not value) then value = nil end
    setenv_posix(name, value, true)
-   chkMP(name, value, adding)
    return o
 end
 
@@ -429,9 +428,7 @@ function M.unset(self)
    self.value = false
    self.type  = 'var'
    setenv_posix(self.name, nil, true)
-   -- An empty string is passed so updateMPathA (inside chkMP) updates the
-   -- internal structures correctly (nil would be ignored)
-   chkMP(self.name, "", adding)
+   chkMP(self.name, nil, adding)
 end
 
 --------------------------------------------------------------------------

--- a/src/Var.lua
+++ b/src/Var.lua
@@ -156,6 +156,7 @@ end
 -- @param value The value assigned to the variable.
 -- @param sep The separator character.  (By default it is ":")
 function M.new(self, name, value, sep)
+   local adding = true
    local o = {}
    setmetatable(o,self)
    self.__index = self
@@ -165,6 +166,7 @@ function M.new(self, name, value, sep)
    extract(o)
    if (not value) then value = nil end
    setenv_posix(name, value, true)
+   chkMP(name, value, adding)
    return o
 end
 
@@ -360,11 +362,13 @@ end
 -- @param self A Var object
 -- @param value the value to set.
 function M.set(self,value)
+   local adding = true
    if (not value) then value = false end
    self.value = value
    self.type  = 'var'
    if (not value) then value = nil end
    setenv_posix(self.name, value, true)
+   chkMP(self.name, value, adding)
 end
 
 --------------------------------------------------------------------------
@@ -421,9 +425,13 @@ end
 -- Unset the environment variable.
 -- @param self A Var object
 function M.unset(self)
+   local adding = false
    self.value = false
    self.type  = 'var'
    setenv_posix(self.name, nil, true)
+   -- An empty string is passed so updateMPathA (inside chkMP) updates the
+   -- internal structures correctly (nil would be ignored)
+   chkMP(self.name, "", adding)
 end
 
 --------------------------------------------------------------------------


### PR DESCRIPTION
This is an embarrassing PR for two reasons:

1. I made it out of the embarrassment it would be to open another issue in such short amount of time without contributing in any other way.
2. It is motivated by the issue I'll describe below, which today I can't reproduce anymore.

I need a module that re-sets most entries in `MODULEPATH`. These entries are substituted by others. To do it, but preserve the order, I get the `MODULEPATH` string, make the corresponding substitutions, and push it with `pushenv`. The error I've seen yesterday, is that Lmod complained with something like:

> "Lmod Warning:  The environment MODULEPATH has been changed in unexpected ways.".

I believe now that I saw this error because I was mistakenly using an ancient version of Lmod, because today, to check this PR, I couldn't reproduce the issue.

Because I thought I was using the last version of lmod when I got that error, I started poking around to see where was the issue and saw that `pushenv`, `setenv` and `unsetenv` don't check for changes in `$MODULEPATH` with `chkMP` (through the `set` and `unset` methods from`Var`), like `prepend_path`, `append_path` and `remove_path` do. So I added that check.

In my view, if `prepend_path`, `append_path` and `remove_path` do that check, `pushenv`, `setenv` and `unsetenv` should do the same. But since I can't reproduce the issue anymore I don't know if this check is necessary at all. Lmod apparently became smart enough to deal with external changes to `$MODULEPATH`, which might make all calls to `chkMP` useless?