### PR TITLE
Fixed bug in LocationT.lua, where sometimes Lmod tried to interate over nil

### DIFF
--- a/src/LocationT.lua
+++ b/src/LocationT.lua
@@ -84,7 +84,7 @@ local function build(moduleA)
       dbg.fini("LocationT build")
       return locationT
    end
-   local T = moduleA[1].T
+   local T = moduleA[1].T or {}
 
    for sn,v in pairs(T) do
       if (v.file) then
@@ -97,7 +97,7 @@ local function build(moduleA)
    end
 
    for i = 2,#moduleA do
-      T = moduleA[i].T
+      T = moduleA[i].T or {}
       for sn, v in pairs(T) do
          local origT   = locationT[sn]
          local lctnT   = locationT[sn] or {}


### PR DESCRIPTION
I do not know why, but under certain circumstances Lmod tried to call `pairs(T)`, with `T` being `nil`:

```

/usr/bin/lua: ...cal/software/juropa3/lmod/lmod/libexec/LocationT.lua:101: bad argument #1 to 'pairs' (table expected, got nil)
stack traceback:
	[C]: in function 'pairs'
	...cal/software/juropa3/lmod/lmod/libexec/LocationT.lua:101: in function 'build'
	...cal/software/juropa3/lmod/lmod/libexec/LocationT.lua:116: in function 'new'
	...local/software/juropa3/lmod/lmod/libexec/ModuleA.lua:479: in function 'search'
	...r/local/software/juropa3/lmod/lmod/libexec/MName.lua:184: in function 'lazyEval'
	...r/local/software/juropa3/lmod/lmod/libexec/MName.lua:238: in function 'fn'
	.../local/software/juropa3/lmod/lmod/libexec/Master.lua:461: in function 'reloadAll'
	.../local/software/juropa3/lmod/lmod/libexec/Master.lua:347: in function 'load'
	...software/juropa3/lmod/lmod/libexec/MasterControl.lua:793: in function 'load'
	...software/juropa3/lmod/lmod/libexec/MasterControl.lua:769: in function 'load_usr'
	...ocal/software/juropa3/lmod/lmod/libexec/cmdfuncs.lua:423: in function 'cmd'
	/usr/local/software/juropa3/lmod/lmod/libexec/lmod:467: in function 'main'
	/usr/local/software/juropa3/lmod/lmod/libexec/lmod:514: in main chunk
	[C]: ?

```

or 

```
Lmod has detected the following error:  Unable to load module:
     /usr/local/software/juropa3knl/Stages/2017a/UI/Compilers/GCC/5.4.0.lua: ...cal/software/juropa3/lmod/lmod/libexec/LocationT.lua:89: bad argument #1 to 'pairs' (table expected, got nil)
```

I do not have an easily reproducible example that triggers the issue. It is in the context of using `pushenv` to do a manual swap of trees. I happens just when certain modules in the hierarchy were loaded at the moment of doing the swapping. This PR seems to fix the issue, and sanitizing the input to `pairs` doesn't seem such a bad idea.