### PR TITLE
Add hook

### DIFF
--- a/contrib/more_hooks/SitePackage.lua
+++ b/contrib/more_hooks/SitePackage.lua
@@ -172,6 +172,19 @@ local function packagebasename(t)
     t.patDir = "^EBROOT.*"
 end
 
+local function avail_module_hook(moduleT)
+    -- This is a costly hook, called for *every* module
+    -- shown in `module avail`. Its argument is a table with
+    -- three elements: sn, fn and fullName
+
+    -- filter out all modules in /etc
+    if moduleT.fn:match("^/etc") then
+        moduleT.sn = nil
+    end
+
+    return moduleT
+end
+
 
 hook.register("load", load_hook)
 hook.register("startup", startup_hook)
@@ -179,3 +192,4 @@ hook.register("msgHook", msg_hook)
 hook.register("SiteName", site_name_hook)
 hook.register("packagebasename", packagebasename)
 hook.register("errWarnMsgHook", errwarnmsg_hook)
+hook.register("avail_module", avail_module_hook)

--- a/src/Hook.lua
+++ b/src/Hook.lua
@@ -67,6 +67,7 @@ local validT =
       packagebasename = false,  -- Hook to find the patterns that spider uses for reverse map
       load_spider     = false,  -- This hook is run evaluating modules for spider/avail
       listHook        = false,  -- This hook gets the list of active modules
+      avail_module    = false,  -- This hook gets called for every module shown in 'avail'
 }
 
 --------------------------------------------------------------------------

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -641,7 +641,8 @@ local function availEntry(defaultOnly, label, searchA, defaultT, entry)
       end
    end
    if (found) then
-      return sn, fullName, fn
+      entry = hook.apply("avail_module", entry) or entry
+      return entry.sn, entry.fullName, entry.fn
    end
    return nil, nil
 end


### PR DESCRIPTION
This adds a hook that allows you to manipulate what is shown in `ml av`. You can filter out certain module as you wish. Keep in mind that this is costly: it's called for every module in avail.

Thoughts @rtmclay? Good idea, bad idea, blow-your-foot-off idea?