### PR TITLE
`dot` is a better example case than GCC...

### DIFF
--- a/docs/source/070_standard_modules.rst
+++ b/docs/source/070_standard_modules.rst
@@ -115,13 +115,13 @@ then you probably want to remove the test for an empty LD_LIBRARY_PATH::
 
     $ module list
     Currently Loaded Modules:
-       1) gcc/5.2     2) StdEnv
+       1) dot     2) StdEnv
 
     $ module load bowtie
     $ bash
     $ module list
     Currently Loaded Modules:
-       1) gcc/5.2     2) StdEnv
+       1) dot     2) StdEnv
 
 Running the bash shell caused the module restore to run which unloaded
 all modules and restored the modules back to the initial set.


### PR DESCRIPTION
...since modulefiles of `GCC` typically define `$LD_LIBRARY_PATH` (and conceal the bug), 
popular `dot` modulefile instead exhibits the bug, so let's use that one