### PR TITLE
Rename z00_StdEnv.sh for proper order of sourcing

### DIFF
--- a/docs/source/070_standard_modules.rst
+++ b/docs/source/070_standard_modules.rst
@@ -12,7 +12,7 @@ login. In ``StdEnv.lua`` is something like: ::
     load("name1","name2","name3")
 
 Using the /etc/profile.d directory system described earlier to create a
-file called ``z00_StdEnv.sh`` ::
+file called ``z01_StdEnv.sh`` ::
 
     if [ -z "$__Init_Default_Modules" ]; then
        export __Init_Default_Modules=1;
@@ -25,7 +25,7 @@ file called ``z00_StdEnv.sh`` ::
        module refresh
     fi
 
-Similar for z00_StdEnv.csh::
+Similar for z01_StdEnv.csh::
 
     if ( ! $?__Init_Default_Modules )  then
       setenv __Init_Default_Modules 1
@@ -37,11 +37,11 @@ Similar for z00_StdEnv.csh::
       module refresh
     endif
 
-The z00_Stdenv.* names are chosen because the files in /etc/profile.d
+The z01_Stdenv.* names are chosen because the files in /etc/profile.d
 are sourced in alphabetical order. These names guarantee they will run
 after the module command is defined.
 
-The z00_Stdenv.sh now includes ``--no_redirect``. This option prevents
+The z01_Stdenv.sh now includes ``--no_redirect``. This option prevents
 sites that configure Lmod to write messages to stdout to write them to
 stderr instead.  This is important as any messages written to stdout
 during shell startup causes scp copies to fail.  Csh/tcsh cannot write
@@ -71,7 +71,7 @@ functions are active, all others functions are ignored.
 The above is an example of how a site might provide a default set of
 modules that a user can override with a default collection. Sites are,
 of course, free to set up Lmod any way they like. The
-minimum required setup (for bash with z00_StdEnv.sh ) would be::
+minimum required setup (for bash with z01_StdEnv.sh ) would be::
 
     if [ -z "$__Init_Default_Modules" ]; then
        export __Init_Default_Modules=1;
@@ -96,7 +96,7 @@ this is that the operating system removes LD_LIBRARY_PATH from the
 environment.  This is a security feature built into the operating
 system.
 
-A site could change z00_StdEnv.sh to have::
+A site could change z01_StdEnv.sh to have::
 
     if [ -z "$__Init_Default_Modules" -o -z "$LD_LIBRARY_PATH" ]; then
        export __Init_Default_Modules=1;

--- a/docs/source/220_tracing.rst
+++ b/docs/source/220_tracing.rst
@@ -41,7 +41,7 @@ example::
        } Time = 0.1875
        /etc/profile.d/z00_lmod.sh{
        } Time = 0.2294
-       /etc/profile.d/z99_StdEnv.sh{
+       /etc/profile.d/z01_StdEnv.sh{
        } Time = 0.2889
      } Time = 0.2929
 

--- a/my_docs/17/TACC_sysadmin_17/talk.tex
+++ b/my_docs/17/TACC_sysadmin_17/talk.tex
@@ -410,7 +410,7 @@ load("gcc","mvapich2")
 \begin{frame}[fragile]
     \frametitle{A Standard Set of Modules (II)}
   \begin{itemize}
-    \item /etc/profile.d/z99\_StdEnv.sh
+    \item /etc/profile.d/z01\_StdEnv.sh
   {\small
     \begin{semiverbatim}
    if [ -z "\$\_\_Init\_Default\_Modules" ]; then
@@ -707,7 +707,7 @@ running: module --initial\_load restore
 \begin{frame}{How to trace Lmod startup behavior}
   \begin{itemize}
     \item How do you trace module commands in /etc/profile.d/*.sh?
-    \item Could modify /etc/profile.d/z99\_StdEnv.sh to turn on
+    \item Could modify /etc/profile.d/z01\_StdEnv.sh to turn on
       LMOD\_TRACING for a particular user. UGH!
     \item Install SHELL STARTUP DEBUG package instead
   \end{itemize}
@@ -735,7 +735,7 @@ running: module --initial\_load restore
     /etc/profile\{
       /etc/profile.d/z00\_lmod.sh\{
       \} Time = 0.0770
-      /etc/profile.d/z99\_StdEnv.sh\{
+      /etc/profile.d/z01\_StdEnv.sh\{
       \} Time = 0.2067
       /etc/bash.bashrc\{
       \} Time = 0.2338


### PR DESCRIPTION
I was following the installation instructions and noticed some odd behavior. If I setup `z00_lmod.sh` and `z00_StdEnv.sh` as suggested in the tutorial and try logging in, I see the following error message:
```
bash: module: command not found
```
`z00_lmod.sh` defines the `module` command, while `z00_StdEnv.sh` runs `module restore`. The problem is that capital S sorts before lowercase L, at least on my system, and so `z00_StdEnv.sh` is sourced before `z00_lmod.sh`. We have a few options to solve this:

1. Rename `z00_lmod.sh` -> `z00_Lmod.sh`
2. Rename `z00_StdEnv.sh` -> `z00_stdenv.sh`
3. Rename `z00_StdEnv.sh` -> `z01_StdEnv.sh`

This PR currently does 1, but now that I think about it 3 is probably safer. Thoughts?