### PR TITLE
make sure spider cache is being used in chkMP

### DIFF
--- a/src/Var.lua
+++ b/src/Var.lua
@@ -104,9 +104,10 @@ local function chkMP(name, value, adding)
       local mt = require("FrameStk"):singleton():mt()
       mt:set_MPATH_change_flag()
       mt:updateMPathA(value)
-      local moduleA      = require("ModuleA"):singleton()
       local cached_loads = cosmic:value("LMOD_CACHED_LOADS")
-      moduleA:update{spider_cache = (cached_loads ~= 'no')}
+      local spider_cache = (cached_loads ~= 'no')
+      local moduleA      = require("ModuleA"):singleton{spider_cache = spider_cache}
+      moduleA:update{spider_cache = spider_cache}
       dbg.fini("chkMP")
    end
 end


### PR DESCRIPTION
This seems to fix the problem we are seeing where the Lmod cache file is not always being used, which results in slow `module load` commands even though we have cached loads enabled.

Without this patch:

```
$ ml --force purge; time ml cluster

real	0m2.505s
user	0m0.516s
sys	0m0.257s
$ ml --force purge; time ml cluster

real	0m2.201s
user	0m0.497s
sys	0m0.256s
$ ml --force purge; time ml cluster

real	0m2.445s
user	0m0.472s
sys	0m0.281s
```

```
$ grep '^open.*SL6.*' strace_no_patch.out  | wc -l
3511
```

with patch:

```
$ ml --force purge; time ml cluster

real	0m0.333s
user	0m0.273s
sys	0m0.058s
$ ml --force purge; time ml cluster

real	0m0.334s
user	0m0.266s
sys	0m0.067s
$ ml --force purge; time ml cluster

real	0m0.332s
user	0m0.301s
sys	0m0.029s
```

```
$ grep '^open.*SL6.*' strace_patched.out  | wc -l
0
```