### PR TITLE
Fixed nil argument in checkforNV

### DIFF
--- a/src/ModuleA.lua
+++ b/src/ModuleA.lua
@@ -486,9 +486,11 @@ function M.search(self, name)
 end
 
 local function l_checkforNV(T)
-   for sn, vv in pairs(T) do
-      if (next(vv.dirT) ~= nil) then
-         return false
+   if (T ~= nil) then
+      for sn, vv in pairs(T) do
+         if (next(vv.dirT) ~= nil) then
+            return false
+         end
       end
    end
    return true


### PR DESCRIPTION
`l_checkforNV` was failing because `T` was `nil`. Lmod < 7.6 worked properly. This fixes it.