### PR TITLE
Make 'ml restore' behave the same for broken collections/inconsistent collections

### DIFF
--- a/src/MT.lua
+++ b/src/MT.lua
@@ -1017,6 +1017,7 @@ function M.getMTfromFile(self,tt)
    local f              = io.open(tt.fn,"r")
    local msg            = tt.msg
    local collectionName = tt.name
+   local force = tt.force
    if (not f) then
       LmodErrorExit()
    end
@@ -1054,8 +1055,8 @@ function M.getMTfromFile(self,tt)
       dbg.print{"sn: ",sn,", hash: ", t[sn], "\n"}
    end
 
-   local force = true
-   Purge(force)
+   local forcepurge = true
+   Purge(forcepurge)
 
    local savedBaseMPATH = l_mt.systemBaseMPATH
    dbg.print{"Saved baseMPATH: ",savedBaseMPATH,"\n"}
@@ -1174,7 +1175,13 @@ function M.getMTfromFile(self,tt)
    activeT = nil  -- done with activeT
    if (#aa > 0) then
       sort(aa)
-      LmodWarning{msg="w_Mods_Not_Loaded",module_list=concatTbl(aa," ")}
+      if (force ~= true) then
+      	      LmodWarning{msg="w_Missing_Coll", collectionName = collectionName, module_list = concatTbl(aa,"\", \"")}
+	      LmodErrorExit()
+	      return false
+      else
+      	      LmodWarning{msg="w_Missing_Coll_Forced", collectionName = collectionName, module_list = concatTbl(aa,"\", \"")}
+      end
    end
 
    --------------------------------------------------------------------------
@@ -1191,9 +1198,13 @@ function M.getMTfromFile(self,tt)
 
    if (#aa > 0) then
       sort(aa)
-      LmodWarning{msg="w_Broken_Coll", collectionName = collectionName, module_list = concatTbl(aa,"\", \"")}
-      if (collectionName ~= "default") then
-         LmodErrorExit()
+      if (force ~= true) then
+              LmodWarning{msg="w_Broken_Coll", collectionName = collectionName, module_list = concatTbl(aa,"\", \"")}
+	      if (collectionName ~= "default") then
+		 LmodErrorExit()
+	      end
+      else
+      	      LmodWarning{msg="w_Broken_Coll_Forced", collectionName = collectionName, module_list = concatTbl(aa,"\", \"")}
       end
       return false
    end

--- a/src/MessageT.lua
+++ b/src/MessageT.lua
@@ -50,6 +50,37 @@ Please submit a consulting ticket if you require additional assistance.
    -- LmodWarnings
    --------------------------------------------------------------------------
    w_Broken_Coll = [==[One or more modules in your %{collectionName} collection have changed: "%{module_list}".
+
+To see the contents of this collection do:
+  $ module describe %{collectionName}
+To forcibly load this collection without the changed modules do:
+  $ module restore %{collectionName} --force
+To rebuild the collection, load the modules you wish then do:
+  $ module save %{collectionName}
+If you no longer want this module collection do:
+  $ rm ~/.lmod.d/%{collectionName}
+
+For more information execute 'module help' or see http://lmod.readthedocs.org/
+No change in modules loaded
+
+]==],
+   w_Missing_Coll = [==[One or more modules in your %{collectionName} collection are missing: "%{module_list}".
+
+To see the contents of this collection do:
+  $ module describe %{collectionName}
+To forcibly load this collection without the missing modules do:
+  $ module restore %{collectionName} --force
+To rebuild the collection, load the modules you wish then do:
+  $ module save %{collectionName}
+If you no longer want this module collection do:
+  $ rm ~/.lmod.d/%{collectionName}
+
+For more information execute 'module help' or see http://lmod.readthedocs.org/
+No change in modules loaded
+
+]==],
+   w_Broken_Coll_Forced = [==[Forcibly loading collection %{collectionName} despite changed modules: "%{module_list}".
+
 To see the contents of this collection do:
   $ module describe %{collectionName}
 To rebuild the collection, load the modules you wish then do:
@@ -58,7 +89,18 @@ If you no longer want this module collection do:
   $ rm ~/.lmod.d/%{collectionName}
 
 For more information execute 'module help' or see http://lmod.readthedocs.org/
-No change in modules loaded
+
+]==],
+   w_Missing_Coll_Forced = [==[Forcibly loading collection %{collectionName} despite missing modules: "%{module_list}".
+
+To see the contents of this collection do:
+  $ module describe %{collectionName}
+To rebuild the collection, load the modules you wish then do:
+  $ module save %{collectionName}
+If you no longer want this module collection do:
+  $ rm ~/.lmod.d/%{collectionName}
+
+For more information execute 'module help' or see http://lmod.readthedocs.org/
 
 ]==],
    w_Broken_FullName = "Badly formed module-version line: module-name must be fully qualified: %{fullName} is not\n",

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -527,7 +527,7 @@ end
 -- state. If a user has a "default" then use that collection.
 -- Otherwise do a "Reset()"
 -- @param collection The user supplied collection name. If *nil* the use "default"
-function Restore(collection)
+function Restore(collection, force)
    dbg.start{"Restore(",collection,")"}
 
    local msg
@@ -565,6 +565,12 @@ function Restore(collection)
 
 
    local masterTbl = masterTbl()
+   local force
+   if (masterTbl.force) then
+      force = true
+   else
+      force = false
+   end
 
    if (collection == "system" ) then
       msg = "system default" .. msgTail
@@ -581,7 +587,7 @@ function Restore(collection)
       Reset(msg)
    else
       local mt      = FrameStk:singleton():mt()
-      local results = mt:getMTfromFile{fn=path, name=myName, msg=msg}
+      local results = mt:getMTfromFile{fn=path, name=myName, msg=msg, force=force}
       if (not results and collection == "default") then
          Reset(msg)
       end


### PR DESCRIPTION
Make 'ml restore' behave the same for broken collections/inconsistent collections. At the moment it is possible to load a collection if there are modules missing, but it's not possible to load if a checksum has changed.

If a checksum has changed, the collection is lost, since '--force' is not available. So I've added also the --force parameter to be consistent with the other parts of lmod:

ml restore 'collectionname' --force  