### PR TITLE
Fixes for fish init

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -102,7 +102,7 @@ LMODRC_INIT               := $(patsubst %, $(srcdir)/init/%, lmodrc.lua)
 ZSH_FUNCS                 := _ml _module
 ZSH_FUNCS                 := $(patsubst %, $(srcdir)/init/zsh/%, $(ZSH_FUNCS))
 
-STARTUP		  	  := profile.in cshrc.in
+STARTUP		  	  := profile.in profile.fish.in cshrc.in
 STARTUP		  	  := $(patsubst %, $(srcdir)/init/%, $(STARTUP))
 
 MSGFNs                    := $(wildcard $(srcdir)/messageDir/*.lua)

--- a/init/fish.in
+++ b/init/fish.in
@@ -2,6 +2,8 @@ set -gx LMOD_PKG @PKG@
 set -gx LMOD_DIR @PKG@/libexec
 set -gx LMOD_CMD @PKG@/libexec/lmod
 
+set -gx MODULESHOME @PKG@
+
 if status -i
    function module
       eval $LMOD_CMD fish $argv | source -

--- a/init/fish.in
+++ b/init/fish.in
@@ -1,6 +1,5 @@
 set -gx LMOD_PKG @PKG@
 set -gx LMOD_DIR @PKG@/libexec
-set -gx LMOD_DIR @PKG@/libexec
 set -gx LMOD_CMD @PKG@/libexec/lmod
 
 if status -i
@@ -14,7 +13,7 @@ else
 end
 
 function ml
-   eval $LMOD_DIR/ml $argv | source -
+   eval $LMOD_DIR/ml_cmd $argv | source -
 end
 
 function clearMT

--- a/init/profile.fish.in
+++ b/init/profile.fish.in
@@ -1,0 +1,83 @@
+#!/usr/bin/env fish
+# -*- fish-shell-script -*-
+########################################################################
+#  This is the system wide source file for setting up
+#  modules in Fish:
+#
+########################################################################
+
+if test (id -u) -ne 0
+
+    if test -n "$MODULEPATH_ROOT"
+
+        if test -n "$USER"
+            set -gx USER "$LOGNAME"  # make sure $USER is set
+        end
+        set -gx LMOD_sys (uname)
+
+        set -gx MODULEPATH_ROOT "@modulepath_root@"
+
+        set MODULEPATH_INIT "@modulepath_init@"
+        
+        if test -e "$MODULEPATH_INIT" 
+            for str in (cat "$MODULEPATH_INIT" | sed 's/#.*$//')  # Allow end-of-line comments.
+                for dir in (ls -d "$str")
+                    set -gx MODULEPATH (@PKG@/libexec/addto --append MODULEPATH $dir)
+                end
+            end
+        else
+            set -xg MODULEPATH (@PKG@/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys $MODULEPATH_ROOT/Core)
+            set -xg MODULEPATH (@PKG@/libexec/addto --append MODULEPATH @PKG@/modulefiles/Core)
+        end
+
+        set -xg FISH_ENV @PKG@/init/fish
+
+        #
+        # If MANPATH is empty, Lmod is adding a trailing ":" so that
+        # the system MANPATH will be found
+        if test -n "$MANPATH"
+            set -xg MANPATH ":"
+        end
+
+        set -gx MANPATH (@PKG@/libexec/addto MANPATH @PKG@/share/man)
+    end
+
+    set PS_CMD @ps@
+    if not test -x $PS_CMD
+        if test -x /bin/ps
+            set PS_CMD /bin/ps
+        else if test -x /usr/bin/ps
+            set PS_CMD /usr/bin/ps
+        end
+    end
+
+    set EXPR_CMD @expr@
+    if not test -x $EXPR_CMD
+        if test -x /usr/bin/expr
+            set EXPR_CMD /usr/bin/expr
+        else if test -x /bin/expr
+            set EXPR_CMD /bin/expr
+        end
+    end
+
+    set BASENAME_CMD @basename@
+    if not test -x $BASENAME_CMD
+        if test -x /bin/basename
+            set BASENAME_CMD /bin/basename
+        else if test -x /usr/bin/basename
+            set BASENAME_CMD /usr/bin/basename
+        end
+    end
+
+
+    set my_shell (eval "$PS_CMD -p %self -ocomm=")
+    set my_shell (eval "$EXPR_CMD \"$my_shell\" : '-*\(.*\)'")
+    set my_shell (eval "$BASENAME_CMD $my_shell")
+
+    if test -f @PKG@/init/$my_shell
+        source  @PKG@/init/$my_shell >/dev/null # Module Support
+    else
+        source  @PKG@/init/sh        >/dev/null # Module Support
+    end
+end
+


### PR DESCRIPTION
This is a collection of fixes to problems outlined in #334 for fish shell support in lmod.

To get Fish working for Lmod, you should link your `init/profile.fish` file into one of fish's `conf.d` directories. You could also do:
```
source (brew --prefix lmod)/lmod/init/fish
set -gx MODULEPATH /usr/local/Cellar/lmod/7.6.11/modulefiles/Darwin:/usr/local/Cellar/lmod/7.6.11/modulefiles/Core:/usr/local/Cellar/lmod/7.6.11/lmod/modulefiles/Core
```
where MODULEPATH comes from the bash version. 