### PR TITLE
Fix fish typo

### DIFF
--- a/init/profile.fish.in
+++ b/init/profile.fish.in
@@ -8,7 +8,7 @@
 
 if test (id -u) -ne 0
 
-    if test -n "$MODULEPATH_ROOT"
+    if test -z "$MODULEPATH_ROOT"
 
         if test -n "$USER"
             set -gx USER "$LOGNAME"  # make sure $USER is set


### PR DESCRIPTION
In #335 I made a typo; `-n` turned into `-z`. In worked running fish from bash but failed when running fish as a default shell. This fixes the typo.