### PR TITLE
Bugfix: Check if variable "cmdArgsL" exists before using it.

### DIFF
--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -540,8 +540,10 @@ proc cmdargs { cmd args } {
 	    lappend cmdArgsL "\"$val\""
 	#}
     }
-    set cmdArgs [join $cmdArgsL ","]
-    puts stdout "$cmd\($cmdArgs\)"
+    if {[info exists cmdArgsL]} {
+        set cmdArgs [join $cmdArgsL ","]
+        puts stdout "$cmd\($cmdArgs\)"
+    }
 }
 
 proc depends-on { args} {
@@ -571,8 +573,10 @@ proc system { args } {
     foreach arg $args {
         lappend cmdArgsL "$arg"
     }
-    set cmdArgs [join $cmdArgsL " "]
-    puts stdout "execute\{cmd=\"$cmdArgs\",modeA = \{\"all\"\}\}"
+    if {[info exists cmdArgsL]} {
+        set cmdArgs [join $cmdArgsL " "]
+        puts stdout "execute\{cmd=\"$cmdArgs\",modeA = \{\"all\"\}\}"
+    }
 }
 
 proc tryloadcmd { args } {


### PR DESCRIPTION
I was getting the following message while trying to load a legacy tcl module:

`$ module load 7.6.00alpha_rev7690-ompi
Lmod has detected the following error:
/apps/[...]/7.6.00alpha_rev7690-ompi: (7.6.00alpha_rev7690-ompi): can't read
"cmdArgsL": no such variable
While processing the following module(s):
    Module fullname           Module Filename
    ---------------           ---------------
    7.6.00alpha_rev7690-ompi  /apps/[...]/7.6.00alpha_rev7690-ompi
`

After applying the fix, it just works fine.