### PR TITLE
mentions ready-to-use ansible role in docs

### DIFF
--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -137,6 +137,23 @@ very important that the trailing semicolon are there.  They are
 replaced by the built-in system path.
 
 
+Using Ansible
+~~~~~~~~~~~~~
+
+There is a `ready-to-use Ansible role
+<https://galaxy.ansible.com/idiv-biodiversity/lmod/>` that allows you to
+install Lmod conveniently from Ansible. The role was written with installation
+on HPC clusters in mind, i.e. it is possible to install Lmod into a global,
+networked file system share on only a single host, while all other hosts
+install just the Lmod dependencies and the shell configuration files.
+Nevertheless, it is of course possible to install Lmod with this role on a
+single server. Also, the role supports the transition to Lmod as described in
+:ref:`transition-to-lmod`.
+
+You can find the complete role documentation `here
+<https://github.com/idiv-biodiversity/ansible-role-lmod#ansible-role-lmod>`.
+
+
 Why does Lmod install differently?
 ----------------------------------
 

--- a/docs/source/045_transition.rst
+++ b/docs/source/045_transition.rst
@@ -1,3 +1,5 @@
+.. _transition-to-lmod:
+
 How to Transition to Lmod (or how to test Lmod without installing it for all)
 =============================================================================
 


### PR DESCRIPTION
I have written an Ansible [role that installs Lmod](https://github.com/idiv-biodiversity/ansible-role-lmod) which we already use to deploy Lmod at our HPC cluster.

I have written a small section mentioning this role in the docs in the hope that it will be useful to others esp. those who already use Ansible.