### PR TITLE
Fix quote marks in rsyslog.conf modification

### DIFF
--- a/docs/source/300_tracking_module_usage.rst
+++ b/docs/source/300_tracking_module_usage.rst
@@ -119,7 +119,7 @@ Have "master" send the tracking messages to a separate computer.
 
 You can add the following to master's /etc/rsyslog.conf file::
 
-   if $programname contains ‘ModuleUsageTracking’ then @module_usage_tracking
+   if $programname contains 'ModuleUsageTracking' then @module_usage_tracking
    &~
 
 Where you change "module_usage_tracking" into a real machine name.


### PR DESCRIPTION
The paired quote marks used on the doc page for the suggested rsyslog.conf modification don't work with rsyslog if the text is copy and pasted. This replaces them with single unpaired quote marks.