### PR TITLE
Show logo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 ![Lmod Logo](https://github.com/TACC/Lmod/raw/master/logos/2x/Lmod-4color%402x.png)
+
 [![Build Status](https://travis-ci.org/TACC/Lmod.svg?branch=master)](https://travis-ci.org/TACC/Lmod)
 [![Documentation Status](https://readthedocs.org/projects/lmod/badge/?version=latest)](https://lmod.readthedocs.io/en/latest/?badge=latest)
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+![Lmod Logo](https://github.com/TACC/Lmod/raw/master/logos/2x/Lmod-4color%402x.png)
 [![Build Status](https://travis-ci.org/TACC/Lmod.svg?branch=master)](https://travis-ci.org/TACC/Lmod)
 [![Documentation Status](https://readthedocs.org/projects/lmod/badge/?version=latest)](https://lmod.readthedocs.io/en/latest/?badge=latest)
 


### PR DESCRIPTION
The logo deserves a place in the `README.md`

How does it look: https://github.com/wpoely86/Lmod/tree/logo