### PR TITLE
fix path for fix shell

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -338,7 +338,7 @@ zsh_tab_funcs: $(ZSH_FUNCS)
         fi
 
 fish_tab_funcs: $(FISH_FUNCS)
-	cp $^ $(DESTDIR)$(INIT)/fish 2>/dev/null
+	cp $^ $(DESTDIR)$(INIT)/ 2>/dev/null
 
 makefile: $(srcdir)/Makefile.in ./config.status
 	./config.status $@

--- a/init/profile.fish.in
+++ b/init/profile.fish.in
@@ -32,8 +32,6 @@ if test (id -u) -ne 0
 
         set -xg FISH_ENV @PKGV@/init/fish
 
-	set -p fish_complete_path @PKGV@/init/fish
-
         #
         # If MANPATH is empty, Lmod is adding a trailing ":" so that
         # the system MANPATH will be found
@@ -44,5 +42,7 @@ if test (id -u) -ne 0
         set -gx MANPATH (@PKGV@/libexec/addto MANPATH @PKGV@/share/man)
     end
     source  @PKGV@/init/fish >/dev/null # Module Support
+    
+    set -p fish_complete_path @PKGV@/init/
 end
 


### PR DESCRIPTION
thanks @kcgthb for your commits. Now it works. There was a bug because I was overwriting the `fish` executable. Now should be fixed