### PR TITLE
fix test

### DIFF
--- a/init/profile.fish.in
+++ b/init/profile.fish.in
@@ -35,7 +35,7 @@ if test (id -u) -ne 0
         #
         # If MANPATH is empty, Lmod is adding a trailing ":" so that
         # the system MANPATH will be found
-        if test -n "$MANPATH"
+        if test -z "$MANPATH"
             set -xg MANPATH ":"
         end
 


### PR DESCRIPTION
the test was incorrect. before this patch, `man` was not working anymore after the `source` of `profile.fish`. Now it works as expected