### PR TITLE
Changed text to make which tcl libraries needed for CentOS 7.

### DIFF
--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -83,6 +83,7 @@ Using Your Package Manager
 If you didn't install the lua tar ball described above then  
 you can use your package manager for your OS to install Lua. You will
 also need the matching packages: lua Filesystem (lfs) and luaposix.
+
 On Ubuntu Linux, the following packages will work::
 
    liblua5.1-0
@@ -96,17 +97,19 @@ On Ubuntu Linux, the following packages will work::
 Note; Centos may require looking the EPEL repo.  At TACC we install the
 following rpms::
 
+   lua-5.1.4-15.el7.x86_64
+   lua-bitop-1.0.2-3.el7.x86_64
+   lua-devel-5.1.4-15.el7.x86_64
+   lua-filesystem-1.6.2-2.el7.x86_64
+   lua-json-1.3.2-2.el7.noarch
+   lua-lpeg-0.12-1.el7.x86_64
    lua-posix-32-2.el7.x86_64
    lua-term-0.03-3.el7.x86_64
-   lua-bitop-1.0.2-3.el7.x86_64
-   lua-filesystem-1.6.2-2.el7.x86_64
-   lua-devel-5.1.4-15.el7.x86_64
-   lua-lpeg-0.12-1.el7.x86_64
-   lua-5.1.4-15.el7.x86_64
-   lua-json-1.3.2-2.el7.noarch
-   tcl-devel-8.5.13-8.el7.x86_64 
 
-You will also need the libtcl and tcl packages as well.
+You will also need the tcl and tcl-devel packages as well.::
+
+   tcl-8.5.13-8.el7.x86_64
+   tcl-devel-8.5.13-8.el7.x86_64 
 
 
 Using Luarocks


### PR DESCRIPTION
The prior text used the term `libtcl` which isn't a package name in CentOS.

I changed that to `tcl-devel` and reworded the text.

I added a paragraph break before enumerating the Ubuntu packages.

I sorted the list of installed Lua packages to match what `rpm -qa` produces
to facilitate comparison between installed and documented packages.

I moved the install tcl-devel package name to its own block, as the text
describes the Lua packages, then the TCL packages, and I added the package
name for the main tcl package.

There is an EPEL package, `tcllib`, which is not, I believe, required for Lmod, and was
the source of my confusion, hence this PR.
```
Name        : tcllib
Arch        : noarch
Version     : 1.14
Release     : 1.el7
Size        : 8.9 M
Repo        : installed
From repo   : epel
Summary     : The standard Tcl library
URL         : http://tcllib.sourceforge.net/
License     : TCL
Description : Tcllib, the Tcl Standard Library is a collection of Tcl packages
            : that provide utility functions useful to a large collection of Tcl
            : programmers.
```