### PR TITLE
Add basic math functions to module sandbox

### DIFF
--- a/src/sandbox.lua
+++ b/src/sandbox.lua
@@ -91,6 +91,8 @@ local sandbox_env = {
                loadlib = package.loadlib, path = package.path, preload = package.preload,
                seeall = package.seeall },
 
+  math     = { floor = math.floor, ceil = math.ceil, min = math.min, max = math.max },
+
   ------------------------------------------------------------
   -- lmod functions
   ------------------------------------------------------------


### PR DESCRIPTION
We wanted to do some basic math in a module and I noticed that there are no math functions in the sandbox. I've added a couple of the most useful ones (given that bash only knows about integers).

Use case: setting the stack size of java to 80% of the memory inside a job automatically.