### PR TITLE
Add example function get_avail_memory to the sandbox

### DIFF
--- a/contrib/more_hooks/README.md
+++ b/contrib/more_hooks/README.md
@@ -17,8 +17,8 @@ The version of this `SitePackage.lua` used in production can be at
 https://github.com/hpcugent/Lmod-UGent/
 
 It also contains a `get_avail_memory` function that is exported to the module sandbox. It
-can be used to find out if the memory is limited (by cgroup) in the environment of
-the module. Example usage for a Java module:
+can be used to find out if the memory is limited (by cgroups) in the environment where
+the module is loaded. Example usage for a Java module:
 
 ```lua
 local mem = get_avail_memory()

--- a/contrib/more_hooks/README.md
+++ b/contrib/more_hooks/README.md
@@ -15,3 +15,14 @@ at https://github.com/hpcugent/logstash-patterns
 
 The version of this `SitePackage.lua` used in production can be at
 https://github.com/hpcugent/Lmod-UGent/
+
+It also contains a `get_avail_memory` function that is exported to the module sandbox. It
+can be used to find out if the memory is limited (by cgroup) in the environment of
+the module. Example usage for a Java module:
+
+```lua
+local mem = get_avail_memory()
+if mem then
+    setenv("JAVA_TOOL_OPTIONS",  "-Xmx" .. math.floor(mem*0.8))
+end
+```

--- a/contrib/more_hooks/SitePackage.lua
+++ b/contrib/more_hooks/SitePackage.lua
@@ -197,7 +197,8 @@ end
 
 
 local function get_avail_memory()
-    -- If a limit is set, return the maximum allowed memory, else nil
+    -- If a limit is set at the point the module is loaded,
+    -- return the maximum allowed memory, else nil
 
     -- look for the memory cgroup (if any)
     local cgroup = nil

--- a/contrib/more_hooks/SitePackage.lua
+++ b/contrib/more_hooks/SitePackage.lua
@@ -196,6 +196,41 @@ local function visible_hook(modT)
 end
 
 
+local function get_avail_memory()
+    -- If a limit is set, return the maximum allowed memory, else nil
+
+    -- look for the memory cgroup (if any)
+    local cgroup = nil
+    for line in io.lines("/proc/self/cgroup") do
+        cgroup = line:match("^[0-9]+:memory:(.*)$")
+        if cgroup then
+            break
+        end
+    end
+
+    if not cgroup then
+        return nil
+    end
+
+    -- read of the current maximum allowed memory usage (memory + swap)
+    local memory_file = io.open("/sys/fs/cgroup/memory/" .. cgroup .. "/memory.memsw.limit_in_bytes")
+
+    if not memory_file then
+        return nil
+    end
+
+    local memory_value = tonumber(memory_file:read())
+    memory_file:close()
+
+    -- if the value is 2^63-1 (rounded down to multiples of 4096), it's unlimited
+    if memory_value == 9223372036854771712 then
+        return nil
+    end
+
+    return memory_value
+end
+
+
 hook.register("load", load_hook)
 hook.register("startup", startup_hook)
 hook.register("msgHook", msg_hook)
@@ -203,3 +238,7 @@ hook.register("SiteName", site_name_hook)
 hook.register("packagebasename", packagebasename)
 hook.register("errWarnMsgHook", errwarnmsg_hook)
 hook.register("isVisibleHook", visible_hook)
+
+sandbox_registration{
+    get_avail_memory = get_avail_memory,
+}


### PR DESCRIPTION
It's just an example how to figure out the maximum allowed memory inside
the environment of a module (if any limit is set at all).