### PR TITLE
Honour quiet option in module reset

### DIFF
--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -546,7 +546,7 @@ function Reset(msg)
    default = default:gsub(" *, *",":")
    default = default:gsub(" +",":")
 
-   if (msg ~= false) then
+   if (msg ~= false and not quiet()) then
       io.stderr:write(i18n("m_Reset_SysDflt",{}))
    end
 


### PR DESCRIPTION
Many commands go quiet when the "-q" option or LMOD_QUIET environment variables are set, but module reset was ignoring it. This PR addresses that problem by adding a simple check before issuing the m_Reset_SysDflt message.