### PR TITLE
allow root user to use lmod in fish shell

### DIFF
--- a/init/profile.fish.in
+++ b/init/profile.fish.in
@@ -10,7 +10,7 @@ if test -z "$LMOD_ALLOW_ROOT_USE"
     set LMOD_ALLOW_ROOT_USE "@lmod_allow_root_use@"
 end
 
-if test $LMOD_ALLOW_ROOT_USE != no
+if test $LMOD_ALLOW_ROOT_USE != yes
     if test (id -u) = 0
        exit 0
     end


### PR DESCRIPTION
correct the LMOD_ALLOW_ROOT_USE logic.