### PR TITLE
Possibly incorrect opt placement for zsh

### DIFF
--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -381,8 +381,8 @@ file can be in a number of places but is typically in ``/etc/zshenv`` or
         if [ -r $i ]; then
           . $i
         fi
-      setopt nomatch
       done
+      setopt nomatch
     fi
     
 Ksh:


### PR DESCRIPTION
I might be wrong but seems like the intention would be to use `setopt no_nomatch`
for the entire loop and not just the first file.