### PR TITLE
adding providedByT argument to Level0_terse when using 'module keyword' in combination with '--terse'

### DIFF
--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -248,7 +248,7 @@ function Keyword(...)
    local kywdT,kywdExtsT        = spider:searchSpiderDB(pack(...), dbT, providedByT)
 
    if (terse) then
-      shell:echo(Spider:Level0_terse(kywdT))
+      shell:echo(Spider:Level0_terse(kywdT, providedByT))
       dbg.fini("Keyword")
       return
    end


### PR DESCRIPTION
This fixes a minor bug which caused an error when using `module --terse keyword`  as the `providedByT` argument was missing when calling the `Level0_terse` function.