### PR TITLE
Fix `module save` dependence on `lua` in PATH.

### DIFF
--- a/pkgs/term/term/cursor.lua
+++ b/pkgs/term/term/cursor.lua
@@ -21,7 +21,7 @@
 local term = require 'term.core'
 
 return {
-  goto    = term.maketermfunc '%d;%dH',
+  ['goto']= term.maketermfunc '%d;%dH',
   goup    = term.maketermfunc '%d;A',
   godown  = term.maketermfunc '%d;B',
   goright = term.maketermfunc '%d;C',

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -224,7 +224,7 @@ function findLuaProg()
    if (luaprog:sub(1,1) == "@") then
       luaprog, found = findInPath("lua")
    else
-      found = isFile(luaCmd) and posix.access(luaCmd, "x")
+      found = isFile(luaprog) and posix.access(luaprog, "x")
    end
    if (not found) then
       LmodError{msg="e_Failed_2_Find", name = "lua"}


### PR DESCRIPTION
When Lmod is configured `--with-lua` custom Lua outside the `PATH`, and no
other `lua` implementation is available, `module save` fails with:

    Lmod has detected the following error:  Unable to find: "lua".

Solve this by mirroring logic from `l_error_on_missing_loaded_modules()`:
Check if the first character of `@path_to_lua@` is '@' (indicating no
substitutions), and if it is not, employ that path unconditionally.

NB: It is not useful to supply `findInPath("lua", "@path_to_lua@:" .. path)` because `@path_to_lua@` is not a directory but a file or a symlink to one, and thus `lua` cannot be found beneath it.