### PR TITLE
add github action workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,49 @@
+name: run Lmod tests
+on: [push, pull_request]
+
+jobs:
+  Lmod_tests:
+      runs-on: ubuntu-latest
+      strategy:
+        matrix:
+          luaVersion: ["5.1", "5.2", "5.3", "5.4"]
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: install dependencies
+        run: sudo apt-get install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh
+      - name: set up lua
+        uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+      - name: install luarocks
+        uses: leafo/gh-actions-luarocks@v4.0.0
+      - name: install lua dependencies
+        run: |
+          luarocks install luaposix
+          luarocks install luafileSystem
+          luarocks install luajson
+          luarocks install lua-term
+      - name: set up Hermes
+        run: |
+         cd /tmp
+         git clone https://github.com/rtmclay/Hermes.git
+         echo "$PWD/Hermes/bin" >> $GITHUB_PATH
+         cd -
+      - name: Run tests
+        run: tm
+        env:
+          # make sure the end2end finds tcl.h
+          CFLAGS: -I/usr/include/tcl8.6
+      - name: show output of failed tests
+        if: ${{ failure() }}
+        run: |
+         # diff stdout/stderr for all tests in case of failure
+         for dir in $(ls -pd rt/* | grep '/$'); do
+           echo ">>>> ${dir}/err.txt"
+           diff -u ${dir}/t1/*/_err.left ${dir}/t1/*/_err.right || echo
+           echo ">>>> ${dir}/out.txt"
+           diff -u ${dir}/out.txt ${dir}/t1/*/out.txt || echo
+         done
+         echo ">>>> end2end output"
+         cat rt/end2end/t1/*/t1.log

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,59 +2,21 @@ name: run Lmod tests
 on: [push, pull_request]
 
 jobs:
-  Lmod_tests_Linux:
-      runs-on: ubuntu-latest
+  Lmod_tests:
+      runs-on: ${{ matrix.os }}
       strategy:
         matrix:
+          os: [ubuntu-latest, macos-latest]
           luaVersion: ["5.1", "5.2", "5.3", "5.4"]
       steps:
       - name: Checkout code
         uses: actions/checkout@v2
-      - name: install dependencies
-        run: sudo apt install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh zsh
-      - name: set up lua
-        uses: leafo/gh-actions-lua@v8.0.0
-        with:
-          luaVersion: ${{ matrix.luaVersion }}
-      - name: install luarocks
-        uses: leafo/gh-actions-luarocks@v4.0.0
-      - name: install lua dependencies
-        run: |
-          luarocks install luaposix
-          luarocks install luafileSystem
-          luarocks install luajson
-          luarocks install lua-term
-      - name: set up Hermes
-        run: |
-         cd /tmp
-         git clone https://github.com/rtmclay/Hermes.git
-         echo "$PWD/Hermes/bin" >> $GITHUB_PATH
-         cd -
-      - name: Run tests
-        run: tm
-      - name: show output of failed tests
-        if: ${{ failure() }}
-        run: |
-         # diff stdout/stderr for all tests in case of failure
-         for dir in $(ls -pd rt/* | grep '/$'); do
-           echo ">>>> ${dir}/err.txt"
-           diff -u ${dir}/t1/*/_err.left ${dir}/t1/*/_err.right || echo
-           echo ">>>> ${dir}/out.txt"
-           diff -u ${dir}/out.txt ${dir}/t1/*/out.txt || echo
-         done
-         echo ">>>> end2end output"
-         cat rt/end2end/t1/*/t1.log
-
-  Lmod_tests_MacOS:
-      runs-on: macos-latest
-      strategy:
-        matrix:
-          luaVersion: ["5.1", "5.2", "5.3", "5.4"]
-      steps:
-      - name: Checkout code
-        uses: actions/checkout@v2
-      - name: install dependencies
+      - name: install dependencies MacOS
+        if: matrix.os == 'macos-latest'
         run: brew install coreutils
+      - name: install dependencies Linux
+        if: matrix.os == 'ubuntu-latest'
+        run: sudo apt install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh zsh
       - name: set up lua
         uses: leafo/gh-actions-lua@v8.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: install dependencies
-        run: sudo apt-get install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh
+        run: sudo apt-get install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh zsh
       - name: set up lua
         uses: leafo/gh-actions-lua@v8.0.0
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -2,7 +2,7 @@ name: run Lmod tests
 on: [push, pull_request]
 
 jobs:
-  Lmod_tests:
+  Lmod_tests_Linux:
       runs-on: ubuntu-latest
       strategy:
         matrix:
@@ -11,7 +11,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v2
       - name: install dependencies
-        run: sudo apt-get install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh zsh
+        run: sudo apt install tcsh tcl8.6 tcl8.6-dev uuid r-base r-base-dev cmake fish tclsh zsh
       - name: set up lua
         uses: leafo/gh-actions-lua@v8.0.0
         with:
@@ -32,9 +32,49 @@ jobs:
          cd -
       - name: Run tests
         run: tm
-        env:
-          # make sure the end2end finds tcl.h
-          CFLAGS: -I/usr/include/tcl8.6
+      - name: show output of failed tests
+        if: ${{ failure() }}
+        run: |
+         # diff stdout/stderr for all tests in case of failure
+         for dir in $(ls -pd rt/* | grep '/$'); do
+           echo ">>>> ${dir}/err.txt"
+           diff -u ${dir}/t1/*/_err.left ${dir}/t1/*/_err.right || echo
+           echo ">>>> ${dir}/out.txt"
+           diff -u ${dir}/out.txt ${dir}/t1/*/out.txt || echo
+         done
+         echo ">>>> end2end output"
+         cat rt/end2end/t1/*/t1.log
+
+  Lmod_tests_MacOS:
+      runs-on: macos-latest
+      strategy:
+        matrix:
+          luaVersion: ["5.1", "5.2", "5.3", "5.4"]
+      steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: install dependencies
+        run: brew install coreutils
+      - name: set up lua
+        uses: leafo/gh-actions-lua@v8.0.0
+        with:
+          luaVersion: ${{ matrix.luaVersion }}
+      - name: install luarocks
+        uses: leafo/gh-actions-luarocks@v4.0.0
+      - name: install lua dependencies
+        run: |
+          luarocks install luaposix
+          luarocks install luafileSystem
+          luarocks install luajson
+          luarocks install lua-term
+      - name: set up Hermes
+        run: |
+         cd /tmp
+         git clone https://github.com/rtmclay/Hermes.git
+         echo "$PWD/Hermes/bin" >> $GITHUB_PATH
+         cd -
+      - name: Run tests
+        run: tm
       - name: show output of failed tests
         if: ${{ failure() }}
         run: |

--- a/Makefile.in
+++ b/Makefile.in
@@ -185,6 +185,8 @@ ifneq ($(HAVE_LUAFILESYSTEM),yes)
   PKG_LFS := lfs
 endif
 FAST_TCL_INTERP           := @FAST_TCL_INTERP@
+TCL_INCLUDE     	  := @TCL_INCLUDE@
+TCL_LIBS	          := @TCL_LIBS@
 ifeq ($(FAST_TCL_INTERP),yes)
   PKGS    := $(PKGS) tcl2lua
   PKG_T2L := tcl2lua
@@ -344,6 +346,7 @@ src/computeHashSum: $(ComputeHashSum)
 tcl2lua:
 	if [ -d $(srcdir)/pkgs/tcl2lua ]; then                             \
            $(MAKE) -C $(srcdir)/pkgs/tcl2lua  LUA_INC=$(LUA_INCLUDE)       \
+	        TCL_INCLUDE=$(TCL_INCLUDE) TCL_LIBS=$(TCL_LIBS)            \
                 LIB=$(DESTDIR)$(LIB) LIBS=@LIBS@ CC=$(CC)                  \
                 SHARE=$(DESTDIR)$(LIBEXEC)                                 \
                 install;                                                   \

--- a/configure
+++ b/configure
@@ -624,7 +624,6 @@ ac_subst_vars='LTLIBOBJS
 LIBOBJS
 ZSH
 ZSH_SITE_FUNCTIONS_DIRS
-pkgConfig
 HAVE_LUA_TERM
 HAVE_LUAFILESYSTEM
 SYS_LUA_CPATH
@@ -646,6 +645,9 @@ SYS_LD_LIB_PATH
 EGREP
 GREP
 CPP
+TCL_LIBS
+TCL_INCLUDE
+pkgConfig
 LUA_SUFFIX
 PATH_TO_LUAC
 PATH_TO_LUA
@@ -4014,14 +4016,64 @@ if test "$ALLOW_TCL_MFILES" = no ; then
 fi
 
 if test "$FAST_TCL_INTERP" = yes ; then
-   OS=$(uname -s)
-   DIR=/usr/include/tcl
-   if test "$OS" = Darwin ; then
-     DIR=$(xcrun --show-sdk-path)
-     DIR=${DIR}/usr/include
+   # todo: use M4 pkg-config macros instead?
+   # Extract the first word of "pkg-config", so it can be a program name with args.
+set dummy pkg-config; ac_word=$2
+{ $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
+$as_echo_n "checking for $ac_word... " >&6; }
+if ${ac_cv_path_pkgConfig+:} false; then :
+  $as_echo_n "(cached) " >&6
+else
+  case $pkgConfig in
+  [\\/]* | ?:[\\/]*)
+  ac_cv_path_pkgConfig="$pkgConfig" # Let the user override the test with a path.
+  ;;
+  *)
+  as_save_IFS=$IFS; IFS=$PATH_SEPARATOR
+for as_dir in $PATH
+do
+  IFS=$as_save_IFS
+  test -z "$as_dir" && as_dir=.
+    for ac_exec_ext in '' $ac_executable_extensions; do
+  if as_fn_executable_p "$as_dir/$ac_word$ac_exec_ext"; then
+    ac_cv_path_pkgConfig="$as_dir/$ac_word$ac_exec_ext"
+    $as_echo "$as_me:${as_lineno-$LINENO}: found $as_dir/$ac_word$ac_exec_ext" >&5
+    break 2
+  fi
+done
+  done
+IFS=$as_save_IFS
+
+  test -z "$ac_cv_path_pkgConfig" && ac_cv_path_pkgConfig=""""
+  ;;
+esac
+fi
+pkgConfig=$ac_cv_path_pkgConfig
+if test -n "$pkgConfig"; then
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: $pkgConfig" >&5
+$as_echo "$pkgConfig" >&6; }
+else
+  { $as_echo "$as_me:${as_lineno-$LINENO}: result: no" >&5
+$as_echo "no" >&6; }
+fi
+
+
+   if  ! test x$pkgConfig = "x"; then
+       for i in tcl tcl8.8 tcl8.7 tcl8.6 tcl8.5; do
+           $pkgConfig --exists $i
+           if test $? = 0; then
+               TCL_INCLUDE=`$pkgConfig --cflags $i | sed -e 's/^-I//' -e 's/ //g'`
+               TCL_LIBS=`$pkgConfig --libs $i`
+               TCL_INCLUDE="$TCL_INCLUDE"
+
+               TCL_LIBS="$TCL_LIBS"
+
+               break
+           fi
+       done
    fi
 
-   CPPFLAGS="-I $DIR"
+   CPPFLAGS="-I $TCL_INCLUDE"
 
 
 ac_ext=c
@@ -4463,7 +4515,7 @@ for ac_lib in '' tcl tcl8.8 tcl8.7 tcl8.6 tcl8.5; do
     ac_res="none required"
   else
     ac_res=-l$ac_lib
-    LIBS="-l$ac_lib  $ac_func_search_save_LIBS"
+    LIBS="-l$ac_lib $TCL_LIBS $ac_func_search_save_LIBS"
   fi
   if ac_fn_c_try_link "$LINENO"; then :
   ac_cv_search_Tcl_CreateInterp=$ac_res

--- a/configure
+++ b/configure
@@ -642,11 +642,11 @@ BASENAME
 PATH_TO_SRC
 SYS_LD_PRELOAD
 SYS_LD_LIB_PATH
+TCL_LIBS
+TCL_INCLUDE
 EGREP
 GREP
 CPP
-TCL_LIBS
-TCL_INCLUDE
 pkgConfig
 LUA_SUFFIX
 PATH_TO_LUAC
@@ -4016,7 +4016,14 @@ if test "$ALLOW_TCL_MFILES" = no ; then
 fi
 
 if test "$FAST_TCL_INTERP" = yes ; then
-   # todo: use M4 pkg-config macros instead?
+   TCL_INCLUDE=/usr/include/tcl
+   TCL_LIBS="-ltcl"
+   OS=$(uname -s)
+   if test "$OS" = Darwin ; then
+     TCL_INCLUDE=$(xcrun --show-sdk-path)
+     TCL_INCLUDE=${DIR}/usr/include
+   fi
+
    # Extract the first word of "pkg-config", so it can be a program name with args.
 set dummy pkg-config; ac_word=$2
 { $as_echo "$as_me:${as_lineno-$LINENO}: checking for $ac_word" >&5
@@ -4064,10 +4071,6 @@ fi
            if test $? = 0; then
                TCL_INCLUDE=`$pkgConfig --cflags $i | sed -e 's/^-I//' -e 's/ //g'`
                TCL_LIBS=`$pkgConfig --libs $i`
-               TCL_INCLUDE="$TCL_INCLUDE"
-
-               TCL_LIBS="$TCL_LIBS"
-
                break
            fi
        done
@@ -4543,6 +4546,11 @@ if test "$ac_res" != no; then :
 else
   rm -f makefile; as_fn_error $? "Unable to build Lmod with -ltcl Please install the tcl devel package or configure --with-fastTCLInterp=no to not require the tcl library" "$LINENO" 5
 fi
+
+
+   TCL_INCLUDE="$TCL_INCLUDE"
+
+   TCL_LIBS="$TCL_LIBS"
 
 fi
 

--- a/configure.ac
+++ b/configure.ac
@@ -615,14 +615,22 @@ if test "$ALLOW_TCL_MFILES" = no ; then
 fi
 
 if test "$FAST_TCL_INTERP" = yes ; then
-   OS=$(uname -s)
-   DIR=/usr/include/tcl
-   if test "$OS" = Darwin ; then
-     DIR=$(xcrun --show-sdk-path)
-     DIR=${DIR}/usr/include
+   # todo: use M4 pkg-config macros instead?
+   AC_PATH_PROG(pkgConfig, pkg-config, "")
+   if  ! test x$pkgConfig = "x"; then
+       for i in tcl tcl8.8 tcl8.7 tcl8.6 tcl8.5; do
+           $pkgConfig --exists $i
+           if test $? = 0; then
+               TCL_INCLUDE=`$pkgConfig --cflags $i | sed -e 's/^-I//' -e 's/ //g'`
+               TCL_LIBS=`$pkgConfig --libs $i`
+               AC_SUBST(TCL_INCLUDE, "$TCL_INCLUDE")
+               AC_SUBST(TCL_LIBS, "$TCL_LIBS")
+               break
+           fi
+       done
    fi
 
-   CPPFLAGS="-I $DIR"
+   CPPFLAGS="-I $TCL_INCLUDE"
 
    AC_CHECK_HEADER(tcl.h,
                    [AC_DEFINE([HAVE_TCL_H], 1, [Define to 1 if you have tcl.h])],[]) 
@@ -632,7 +640,7 @@ if test "$FAST_TCL_INTERP" = yes ; then
       AC_MSG_ERROR([Unable to build Lmod without tcl.h.  Please install the tcl devel package or configure --with-fastTCLInterp=no to not require tcl.h])
    fi
    AC_SEARCH_LIBS(Tcl_CreateInterp,[tcl] [tcl8.8] [tcl8.7] [tcl8.6] [tcl8.5],[],
-                [rm -f makefile; AC_MSG_ERROR([Unable to build Lmod with -ltcl Please install the tcl devel package or configure --with-fastTCLInterp=no to not require the tcl library])])
+                [rm -f makefile; AC_MSG_ERROR([Unable to build Lmod with -ltcl Please install the tcl devel package or configure --with-fastTCLInterp=no to not require the tcl library])], [$TCL_LIBS])
 fi
 
 AC_SUBST(SYS_LD_LIB_PATH)

--- a/configure.ac
+++ b/configure.ac
@@ -615,7 +615,14 @@ if test "$ALLOW_TCL_MFILES" = no ; then
 fi
 
 if test "$FAST_TCL_INTERP" = yes ; then
-   # todo: use M4 pkg-config macros instead?
+   TCL_INCLUDE=/usr/include/tcl
+   TCL_LIBS="-ltcl"
+   OS=$(uname -s)
+   if test "$OS" = Darwin ; then
+     TCL_INCLUDE=$(xcrun --show-sdk-path)
+     TCL_INCLUDE=${DIR}/usr/include
+   fi
+
    AC_PATH_PROG(pkgConfig, pkg-config, "")
    if  ! test x$pkgConfig = "x"; then
        for i in tcl tcl8.8 tcl8.7 tcl8.6 tcl8.5; do
@@ -623,8 +630,6 @@ if test "$FAST_TCL_INTERP" = yes ; then
            if test $? = 0; then
                TCL_INCLUDE=`$pkgConfig --cflags $i | sed -e 's/^-I//' -e 's/ //g'`
                TCL_LIBS=`$pkgConfig --libs $i`
-               AC_SUBST(TCL_INCLUDE, "$TCL_INCLUDE")
-               AC_SUBST(TCL_LIBS, "$TCL_LIBS")
                break
            fi
        done
@@ -641,6 +646,9 @@ if test "$FAST_TCL_INTERP" = yes ; then
    fi
    AC_SEARCH_LIBS(Tcl_CreateInterp,[tcl] [tcl8.8] [tcl8.7] [tcl8.6] [tcl8.5],[],
                 [rm -f makefile; AC_MSG_ERROR([Unable to build Lmod with -ltcl Please install the tcl devel package or configure --with-fastTCLInterp=no to not require the tcl library])], [$TCL_LIBS])
+
+   AC_SUBST(TCL_INCLUDE, "$TCL_INCLUDE")
+   AC_SUBST(TCL_LIBS, "$TCL_LIBS")
 fi
 
 AC_SUBST(SYS_LD_LIB_PATH)

--- a/embed/Makefile
+++ b/embed/Makefile
@@ -6,7 +6,7 @@ OBJ      := $(patsubst %.c, %.o, $(SRC))
 LUAINC   := /opt/apps/lua/lua/include
 OS       := $(shell uname -s)
 
-override CFLAGS   := $(CFLAGS) -DLUA_COMPAT_MODULE -fPIC -I $(LUAINC) -I /usr/include/tcl
+override CFLAGS   := $(CFLAGS) -DLUA_COMPAT_MODULE -fPIC -I $(LUAINC) -I $(TCL_INCLUDE)
 
 ifeq ($(OS),Darwin)
   LIB_OPTION= -bundle -undefined dynamic_lookup #for MacOS X
@@ -23,7 +23,7 @@ $(SONAME):
 	ln -s $(SONAMEV) $@
 
 $(LIBRARY): $(OBJ)
-	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) -lc -ltcl
+	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) -lc $(TCL_LIBS)
 
 install: all
 	cp $(LIBRARY) $(LUA_LIB)

--- a/pkgs/tcl2lua/Makefile
+++ b/pkgs/tcl2lua/Makefile
@@ -11,7 +11,7 @@ ifeq ($(OS),Darwin)
   DIR        := $(DIR)/usr/include
   LIB_OPTION := -bundle -undefined dynamic_lookup #for MacOS X
 else
-  DIR        := /usr/include/tcl
+  DIR        := $(TCL_INCLUDE)
   LIB_OPTION := -shared -Wl,-soname,$(SONAMEV) #for Linux
 endif
 override CFLAGS   := $(CFLAGS) -DLUA_COMPAT_MODULE -fPIC $(LUA_INC) -I $(DIR)
@@ -25,7 +25,7 @@ $(SONAME):
 	ln -s $(SONAMEV) $@
 
 $(LIBRARY): $(OBJ)
-	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) $(LDFLAGS) -lc $(LIBS)
+	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) $(LDFLAGS) -lc $(LIBS) $(TCL_LIBS)
 
 install: all
 	cp -a *.so* $(LIB)


### PR DESCRIPTION
As travis is about to be shut down, time we move to github actions for automatic testing.

However, I can't get the tests to pass for now. See: https://github.com/wpoely86/Lmod/actions/runs/597320897

Fails:
- diff     /home/runner/work/Lmod/Lmod/rt/ck_mtree_syntax/t1/2021_02_24_20_24_59-Linux-x86_64-ck_mtree_syntax
- diff     /home/runner/work/Lmod/Lmod/rt/end2end/t1/2021_02_24_20_24_59-Linux-x86_64-end2end

The end2end one I can fix (it's a header issue), but the `ck_mtree_syntax` I'm unsure of? It looks like the order is just changed?

