### PR TITLE
Set LMOD_VERSION for fish-shell

### DIFF
--- a/init/fish.in
+++ b/init/fish.in
@@ -5,6 +5,8 @@ set -gx LMOD_CMD  @PKG@/libexec/lmod
 
 set -gx MODULESHOME @PKG@
 
+set -gx LMOD_VERSION "@lmod_version@"
+
 set -gx FPATH (@PKGV@/libexec/addto --append FPATH @PKGV@/init/ksh_funcs)
 
 if status -i


### PR DESCRIPTION
It seems the `tcl2lua.tcl` need `LMOD_VERSION`, the [current fish init script](https://github.com/TACC/Lmod/blob/master/init/fish.in) does not set it, leading to the following error

```
/usr/share/lmod/8.4.28/libexec/tcl2lua.tcl dft

no such variable
    (read trace on "env(LMOD_VERSION)")
    invoked from within
"set ModuleToolVersion $env(LMOD_VERSION)"
    (procedure "execute-modulefile" line 5)
    invoked from within
"execute-modulefile $modfile"
    (procedure "main" line 5)
    invoked from within
"main dft"
    ("eval" body line 1)
    invoked from within
"eval main $argv"
    (file "/usr/share/lmod/8.4.28/libexec/tcl2lua.tcl" line 1020)
```