### PR TITLE
Added rc support.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -130,7 +130,7 @@ STANDALONE_PRGM           := src/lmod.in.lua src/addto.in.lua                   
 STANDALONE_PRGM           := $(patsubst %, $(srcdir)/%, $(STANDALONE_PRGM))
 SHELL_INIT                := bash.in cmake.in csh.in ksh.in tcsh.in zsh.in sh.in perl.in R.in \
                              env_modules_python.py.in lmod_bash_completions fish.in           \
-                             lisp.in env_modules_ruby.rb.in
+                             lisp.in env_modules_ruby.rb.in rc.in
 SHELL_INIT                := $(patsubst %, $(srcdir)/init/%, $(SHELL_INIT))
 LMODRC_INIT               := $(patsubst %, $(srcdir)/init/%, lmodrc.lua)
 

--- a/Makefile.in
+++ b/Makefile.in
@@ -144,7 +144,7 @@ FISH_FUNCS                := $(patsubst %, $(srcdir)/init/fish/%, $(FISH_FUNCS))
 KSH_FUNCS                 := clearLmod.in clearMT.in ml.in module.in settarg.in
 KSH_FUNCS                 := $(patsubst %, $(srcdir)/init/ksh_funcs/%, $(KSH_FUNCS))
 
-STARTUP                   := profile.in profile.fish.in cshrc.in
+STARTUP                   := profile.in profile.fish.in profile.rc.in cshrc.in
 STARTUP                   := $(patsubst %, $(srcdir)/init/%, $(STARTUP))
 
 MSGFNs                    := $(wildcard $(srcdir)/messageDir/*.lua)

--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -273,7 +273,7 @@ If this file exists then MODULEPATH_ROOT method is not used.
 
 The ``profile`` file is the Lmod initialization script for the bash and zsh
 shells, the ``cshrc`` file is for tcsh and csh shells, and the ``profile.fish``
-file is for the fish shell. Please copy or link the ``profile`` and ``cshrc``
+file is for the fish shell, etc. Please copy or link the ``profile`` and ``cshrc``
 files to ``/etc/profile.d``, and optionally the fish file to ``/etc/fish/conf.d``::
 
     $ ln -s /opt/apps/lmod/lmod/init/profile        /etc/profile.d/z00_lmod.sh
@@ -420,6 +420,20 @@ as module and ml that provide the module commands.
 **Note**: Zsh users who wish to run ksh scripts that have module
 commands in them will have to export the FPATH variable as FPATH is
 normally a local variable and not exported in zsh.
+
+Rc:
+~~~~
+Rc shells ignore the `/etc/profile.d` directory and source `/lib/rcmain` on startup.
+Global initialization should be placed in that file.
+Login shells (started with `rc -l`) additionally
+read the user's `$HOME/.rcrc` file.
+
+Running the following line on startup will setup the module
+commands for rc users:
+
+```
+mod=/opt/apps/lmod/lmod/init/profile.rc if(test -r $mod) . $mod
+```
 
 Fish:
 ~~~~~

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -35,8 +35,8 @@ variables that specify where the library and header files can be
 found.
 
 Packages can be loaded and unloaded cleanly through the module
-system. All the popular shells are supported: bash, ksh, csh, tcsh,
-zsh.  Also available for perl and python.
+system. All the popular shells are supported: bash, ksh, rc, csh, tcsh,
+fish, zsh.  Also available for perl, python, lisp, cmake, and R.
 
 It is also very easy to switch between different versions of a package
 or remove it.

--- a/init/profile.rc.in
+++ b/init/profile.rc.in
@@ -47,7 +47,7 @@ fn findExec {
        $Nm=/usr/bin/$execNm
     }
   }
-  unset Nm confPath execNm
+  Nm=(); confPath=(); execNm=()
 }
 
 findExec PS_CMD       @ps@        ps

--- a/init/profile.rc.in
+++ b/init/profile.rc.in
@@ -1,0 +1,67 @@
+#!/bin/rc
+########################################################################
+#  This is the system wide source file for setting up modules
+########################################################################
+
+if(! ~ @lmod_allow_root_use@ yes)
+  { ! test -z $"USER_IS_ROOT || ~ `{id -u} 0 } && exit 0
+
+
+if(~ $#MODULEPATH_ROOT 0) {
+  if(~ $#USER 0) USER=$LOGNAME # make sure $USER is set
+  LMOD_sys=`{uname}
+
+  MODULEPATH_ROOT=@modulepath_root@
+  MODULEPATH_INIT=@modulepath_init@
+  if(test -f $MODULEPATH_INIT) {
+     for(dir in `{cat $MODULEPATH_INIT | sed 's/#.*$//'}) { # Allow end-of-line comments.
+        if(test -d $dir)
+           MODULEPATH=`{@PKGV@/libexec/addto --append MODULEPATH $dir}
+     }
+  }
+  if not {
+     MODULEPATH=`{@PKGV@/libexec/addto --append MODULEPATH $MODULEPATH_ROOT/$LMOD_sys $MODULEPATH_ROOT/Core}
+     MODULEPATH=`{@PKGV@/libexec/addto --append MODULEPATH @PKGV@/modulefiles/Core}
+  }
+
+  BASH_ENV=@PKGV@/init/bash
+
+  #
+  # If MANPATH is empty, Lmod is adding a trailing ":" so that
+  # the system MANPATH will be found
+  if(~ $#MANPATH 0)
+    MANPATH=:
+  MANPATH=`{@PKGV@/libexec/addto MANPATH @PKGV@/share/man}
+}
+
+fn findExec {
+  Nm=$1
+  confPath=$2
+  execNm=$3
+  $Nm=$confPath
+  if( ! test -x $confPath) {
+    if(test -x /bin/$execNm)
+       $Nm=/bin/$execNm
+    if not {
+      if(test -x /usr/bin/$execNm)
+       $Nm=/usr/bin/$execNm
+    }
+  }
+  unset Nm confPath execNm
+}
+
+findExec PS_CMD       @ps@        ps
+findExec EXPR_CMD     @expr@      expr
+findExec BASENAME_CMD @basename@  basename
+
+fn findExec
+
+if(test -f @PKGV@/init/rc)
+   . @PKGV@/init/rc >/dev/null # Module Support
+my_shell=()
+MODULEPATH_INIT=()
+
+# Local Variables:
+# mode: shell-script
+# indent-tabs-mode: nil
+# End:

--- a/init/rc.in
+++ b/init/rc.in
@@ -1,0 +1,31 @@
+#!/usr/bin/env rc
+
+#LMOD_ROOT='@lmod_root@'
+LMOD_PKG='@PKG@'
+LMOD_DIR='@PKG@/libexec'
+LMOD_CMD='@PKG@/libexec/lmod'
+MODULESHOME='@PKG@'
+
+fn module {
+  eval `{$LMOD_CMD rc $*}
+}
+
+fn clearMT {
+  eval `{$LMOD_DIR/clearMT_cmd rc}
+}
+
+########################################################################
+#  ml is a shorthand tool for people who can't type moduel, err, module
+#  It is also a combination command:
+#     ml            -> module list
+#     ml gcc        -> module load gcc
+#     ml -gcc intel -> module unload gcc; module load intel
+#  It does much more do: "ml --help" for more information.
+fn ml {
+  eval `{$LMOD_DIR/ml_cmd $*}
+}
+
+# Local Variables:
+# mode: shell-script
+# indent-tabs-mode: nil
+# End:

--- a/shells/BaseShell.lua
+++ b/shells/BaseShell.lua
@@ -264,6 +264,7 @@ local function createShellTbl()
       local Perl         = require('Perl')
       local Python       = require('Python')
       local R            = require('R')
+      local Rc           = require('Rc')
       local Ruby         = require('Ruby')
       s_shellTbl = {
          ["sh"]     = Bash,
@@ -281,6 +282,7 @@ local function createShellTbl()
          ["bare"]   = Bare,
          ["r"]      = R,
          ["R"]      = R,
+         ["rc"]     = Rc,
          ["ruby"]   = Ruby,
       }
    end

--- a/shells/Rc.lua
+++ b/shells/Rc.lua
@@ -1,0 +1,157 @@
+--------------------------------------------------------------------------
+-- Lmod License
+--------------------------------------------------------------------------
+--
+--  Lmod is licensed under the terms of the MIT license reproduced below.
+--  This means that Lmod is free software and can be used for both academic
+--  and commercial purposes at absolutely no cost.
+--
+--  ----------------------------------------------------------------------
+--
+--  Copyright (C) 2008-2018 Robert McLay
+--  Copyright (C) 2021 Oak Ridge National Laboratory
+--
+--  Permission is hereby granted, free of charge, to any person obtaining
+--  a copy of this software and associated documentation files (the
+--  "Software"), to deal in the Software without restriction, including
+--  without limitation the rights to use, copy, modify, merge, publish,
+--  distribute, sublicense, and/or sell copies of the Software, and to
+--  permit persons to whom the Software is furnished to do so, subject
+--  to the following conditions:
+--
+--  The above copyright notice and this permission notice shall be
+--  included in all copies or substantial portions of the Software.
+--
+--  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+--  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+--  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+--  NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+--  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+--  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+--  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+--  THE SOFTWARE.
+--
+--------------------------------------------------------------------------
+
+--------------------------------------------------------------------------
+-- Rc: This is a derived class from BaseShell.  This classes knows how
+--      to expand the environment variable into Rc syntax.
+
+_G._DEBUG          = false
+local posix        = require("posix")
+
+require("strict")
+require("pairsByKeys")
+
+local BaseShell    = require("BaseShell")
+local Rc          = inheritsFrom(BaseShell)
+local dbg          = require("Dbg"):dbg()
+local concatTbl    = table.concat
+local stdout       = io.stdout
+local posix_setenv = posix.setenv
+local cosmic       = require("Cosmic"):singleton()
+Rc.my_name        = 'rc'
+
+--------------------------------------------------------------------------
+-- Rc:alias(): Either define or undefine an Rc shell alias. Remove any
+--             trailing semicolons in module definition.  Then add it back
+--             in.  This way there is one and only one semicolon at the
+--             end.
+
+function Rc.alias(self, k, v)
+  local lineA = {}
+  lineA[#lineA + 1] = "fn "
+  lineA[#lineA + 1] = k
+  lineA[#lineA + 1] = " { "
+  if (k:find("^" .. k .. " ")) then
+    -- detect whether k is an alias for k itself
+    lineA[#lineA + 1] = "builtin "
+  end
+  lineA[#lineA + 1] = v
+  lineA[#lineA + 1] = " $* }\n"
+  local line = concatTbl(lineA,"")
+  stdout:write(line)
+  dbg.print{   line}
+end
+
+--------------------------------------------------------------------------
+-- Rc:shellFunc(): Modify module definition of function truncating
+--                 everything after first semicolon.
+--                 [copied from bash behavior]
+function Rc.shellFunc(self,k,v)
+   if (not v) then
+      stdout:write("fn ",k,"\n")
+      dbg.print{   "fn ",k,"\n"}
+   else
+      --local func = v[1]:gsub(";%s*$","")
+      --stdout:write("fn ",k," { ",func," }\n")
+      --dbg.print{   "fn ",k," { ",func," }\n"}
+      -- Unfortunately, shell functions come only in bash and csh
+      -- types.  They contain $() and "", so are
+      -- unsuitable for execution by rc.
+      -- Neither can they be translated automatically.
+   end
+end
+
+--------------------------------------------------------------------------
+-- Rc:expandVar(): expand a single key-value pair into Rc syntax.
+
+function Rc.expandVar(self, k, v, vType)
+   if (k:find("%.")) then
+      return
+   end
+   local lineA = {}
+   lineA[#lineA + 1] = k
+   lineA[#lineA + 1] = "='"
+   lineA[#lineA + 1] = tostring(v):gsub("'", "''")
+   lineA[#lineA + 1] = "';\n"
+   -- Note: there is no concept of file-scoped local variables in rc
+   -- only command-scoped ones
+   local line = concatTbl(lineA,"")
+   stdout:write(line)
+   if (k:find('^_ModuleTable') == nil) then
+      dbg.print{line}
+   end
+end
+
+function Rc.echo(self, ...)
+   local LMOD_REDIRECT = cosmic:value("LMOD_REDIRECT")
+   if (LMOD_REDIRECT == "no") then
+      posix_setenv("LC_ALL",nil,true)
+      pcall(pager,io.stderr,...)
+      posix_setenv("LC_ALL","C",true)
+   else
+      local argA = pack(...)
+      for i = 1, argA.n do
+         local whole = argA[i]
+         if (whole:sub(-1) == "\n") then
+            whole = whole:sub(1,-2)
+         end
+         for line in whole:split("\n") do
+            line = line:gsub("'","''")
+            stdout:write("echo '",line,"';\n")
+         end
+      end
+   end
+end
+
+--------------------------------------------------------------------------
+-- Rc:unset(): unset a local or env. variable.
+
+function Rc.unset(self, k, vType)
+   if (k:find("%.")) then
+      return
+   end
+   local line = k .. "=()\n"
+   stdout:write(line)
+   dbg.print{   line}
+end
+
+--------------------------------------------------------------------------
+-- Rc:real_shell(): Return true because `rc` is executable.
+
+function Rc.real_shell(self)
+   return true
+end
+
+return Rc

--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -1076,6 +1076,9 @@ switch -regexp -- $g_shellName {
     ^(r)$ {
 	set g_shellType r
     }
+    ^(rc)$ {
+	set g_shellType rc
+    }
     . {
 	set g_shellType broken
     }


### PR DESCRIPTION
This patch adds support for the `rc` shell (https://github.com/benavento/rc).
rc has far fewer issues with quotations than most shells, usually just requiring
transforming `str` into `"'" .. str:gsub("'", "''") .. "'"`

The second commit adds the install-line for `init/profile.rc` into the `Makefile` and teaches `libexec/tcl2lua.tcl` to recognize rc.