### PR TITLE
mnt: changed internal sep name to delim

### DIFF
--- a/docs/source/050_lua_modulefiles.rst
+++ b/docs/source/050_lua_modulefiles.rst
@@ -18,36 +18,36 @@ is the element that was added to the PATH during loading, is removed
 during unloading. The environment variables set during loading are
 unset during unloading.
 
-**prepend_path** ("*PATH*","*/path/to/pkg/bin*"):
+**prepend_path** ("*PATH*", "*/path/to/pkg/bin*"):
    prepend to a path-like variable the value.
 
-**prepend_path** ("*PATH*","*/path/to/pkg/bin*", "*delim*" ):
+**prepend_path** ("*PATH*", "*/path/to/pkg/bin*", "*delim*"):
    prepend to a path-like variable the value. It is possible to add a
    third argument to be the delimiter.  By default is is "*:*", the
    delimiter can be any single character for example " " or  ";"
 
-**prepend_path** {"*PATH*","*/path/to/pkg/bin*", priority=*num* delim="*delim*" }:
+**prepend_path** {"*PATH*", "*/path/to/pkg/bin*", delim="*delim*", priority=*num*}:
    prepend to a path-like variable the value. One can use this form
    **with braces {} instead of parens ()** to specify both a priority
    a non-default delimiter.
 
-**append_path** ("*PATH*","*/path/to/pkg/bin*"):
+**append_path** ("*PATH*", "*/path/to/pkg/bin*"):
    append to a path-like variable the value.
 
-**append_path** ("*PATH*","*/path/to/pkg/bin*", "*delim*" ):
+**append_path** ("*PATH*", "*/path/to/pkg/bin*", "*delim*"):
    append to a path-like variable the value. It is possible to add a
    third argument to be the delimiter.  By default is is "*:*", the
    delimiter can be any single character for example " " or  ";"
 
-**append_path** {"*PATH*","*/path/to/pkg/bin*", priority=*num* delim="*delim*" }:
+**append_path** {"*PATH*", "*/path/to/pkg/bin*", delim="*delim*", priority=*num*}:
    append to a path-like variable the value. One can use this form
    **with braces {} instead of parens ()** to specify both a priority
    a non-default delimiter.
 
-**remove_path** ("*PATH*","*/path/to/pkg/bin*"):
+**remove_path** ("*PATH*", "*/path/to/pkg/bin*"):
    remove value from a path-like variable for both load and unload modes.
 
-**remove_path** ("*PATH*","*/path/to/pkg/bin*" , "*delim*" ):
+**remove_path** ("*PATH*", "*/path/to/pkg/bin*" , "*delim*"):
    remove value from a path-like variable for both load and unload modes.
    It is possible to add a third argument to be the delimiter.  By
    default is is "*:*", the delimiter can be any single character for
@@ -83,11 +83,11 @@ unset during unloading.
      What is printed out when the help command is called. Note that
      the *help string* can be multi-lined.
 
-**pathJoin** ("/a","b/c/","d/"):
+**pathJoin** ("/a", "b/c/", "d/"):
      builds a path: "/a/b/c/d", It combines any number of strings with
      one slash and removes excess slashes. Note that trailing slash is
      removed. If you need a trailing slash then do
-     **pathJoin("/a","b/c") .. "/"** to get "/a/b/c/".
+     **pathJoin("/a", "b/c") .. "/"** to get "/a/b/c/".
 
 **depends_on** ("pkgA", "pkgB", "pkgC"):
      Loads all modules.  When unloading only dependent modules are
@@ -119,7 +119,7 @@ unset during unloading.
 **always_load** ("pkgA", "pkgB", "pkgC"):
      load all modules. However, when this command is reversed, it does nothing.
 
-**set_alias** ("name","value"):
+**set_alias** ("name", "value"):
      define an alias to name with value.
 
 **unload** ("pkgA", "pkgB"):
@@ -187,10 +187,10 @@ The entries below describe several useful commands that come with Lmod that can 
 **splitFileName** ("name"):
     Returns both the directory and the file name. ``local d,f=splitFileName("/a/b/c.ext")``. Then ``d="/a/b"``, ``f="c.ext"``
 
-**LmodMessage** ("string",...):
+**LmodMessage** ("string", ...):
     Prints a message to the user.
 
-**LmodError** ("string","..."):
+**LmodError** ("string", "..."):
     Print Error string and exit without loading the modulefile.
 
 **mode** ():
@@ -213,7 +213,7 @@ The entries below describe several useful commands that come with Lmod that can 
 **LmodVersion** ():
     The version of lmod.
 
-**execute** {cmd="*<any command>*",modeA={"load"}}
+**execute** {cmd="*<any command>*", modeA={"load"}}
     Run any command with a certain mode.  For example
     **execute** {cmd="ulimit -s unlimited",modeA={"load"}} will run
     the command **ulimit -s unlimited** as the last thing that the
@@ -223,12 +223,12 @@ The entries below describe several useful commands that come with Lmod that can 
 Modifier functions to prereq and loads
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-**atleast** ("name","version"):
+**atleast** ("name", "version"):
     This modifier function will only succeed if the module is
     "version" or newer. See the between function for adding a "<" to
     modify the search criteria.
 
-**between** ("name","v1","v2"): This modifier function will only
+**between** ("name", "v1", "v2"): This modifier function will only
     succeed if the module's version is equal to or between "v1" and
     "v2". Note that version "1.2" is the same as "1.2.0.0.0....".
     This means that between("foo","2.7","3.0") would include "foo/3.0"

--- a/src/MC_ComputeHash.lua
+++ b/src/MC_ComputeHash.lua
@@ -122,7 +122,7 @@ end
 function M.prepend_path(self, t)
    local name = t[1]
    if (name ~= "MODULEPATH") then return end
-   ShowCmd("prepend_path", name, t[2], t.sep)
+   ShowCmd("prepend_path", name, t[2], t.delim)
 end
 
 --------------------------------------------------------------------------
@@ -132,7 +132,7 @@ end
 function M.append_path(self, t)
    local name = t[1]
    if (name ~= "MODULEPATH") then return end
-   ShowCmd("append_path", name, t[2], t.sep)
+   ShowCmd("append_path", name, t[2], t.delim)
 end
 
 --------------------------------------------------------------------------
@@ -142,7 +142,7 @@ end
 function M.remove_path(self, t)
    local name = t[1]
    if (name ~= "MODULEPATH") then return end
-   ShowCmd("remove_path", name, t[2], t.sep)
+   ShowCmd("remove_path", name, t[2], t.delim)
 end
 
 --------------------------------------------------------------------------

--- a/src/Master.lua
+++ b/src/Master.lua
@@ -174,15 +174,15 @@ local function registerLoaded(fullName, fn)
    local modFn    = "_LMFILES_"
    local nodups   = true
    local priority = 0
-   local sep      = ":"
+   local delim    = ":"
    if (varT[modList] == nil) then
-      varT[modList] = Var:new(modList, nil, nodups, sep)
+      varT[modList] = Var:new(modList, nil, nodups, delim)
    end
 
    varT[modList]:append(fullName, nodups, priority)
 
    if (varT[modFn] == nil) then
-      varT[modFn] = Var:new(modFn, nil, nodups, sep)
+      varT[modFn] = Var:new(modFn, nil, nodups, delim)
    end
 
    varT[modFn]:append(fn, nodups, priority)
@@ -200,18 +200,18 @@ local function registerUnloaded(fullName, fn)
    local modFn    = "_LMFILES_"
    local where    = "all"
    local nodups   = true
-   local sep      = ":"
+   local delim    = ":"
    local priority = 0
 
    if (varT[modList] == nil) then
-      varT[modList] = Var:new(modList, nil, nodups, sep)
+      varT[modList] = Var:new(modList, nil, nodups, delim)
    end
 
    varT[modList]:remove(fullName, where, priority)
 
 
    if (varT[modFn] == nil) then
-      varT[modFn] = Var:new(modFn, nil, nodups, sep)
+      varT[modFn] = Var:new(modFn, nil, nodups, delim)
    end
 
    varT[modFn]:remove(fn, where, priority)

--- a/src/MasterControl.lua
+++ b/src/MasterControl.lua
@@ -449,7 +449,7 @@ end
 -- @param t A table containing { name, value, nodups=v1, priority=v2}
 function M.prepend_path(self, t)
    dbg.start{"MasterControl:prepend_path(t)"}
-   local sep      = t.delim or ":"
+   local delim    = t.delim or ":"
    local name     = t[1]
    local value    = t[2]
    local nodups   = not allow_dups( not t.nodups)
@@ -460,11 +460,11 @@ function M.prepend_path(self, t)
 
 
    dbg.print{"name:\"",name,"\", value: \"",value,
-             "\", delim=\"",sep,"\", nodups=\"",nodups,
+             "\", delim=\"",delim,"\", nodups=\"",nodups,
              "\", priority=",priority,"\n"}
 
    if (varT[name] == nil) then
-      varT[name] = Var:new(name, nil, nodups, sep)
+      varT[name] = Var:new(name, nil, nodups, delim)
    end
 
    -- Do not allow dups on MODULEPATH like env vars.
@@ -479,7 +479,7 @@ end
 -- @param self A MasterControl object
 -- @param t A table containing { name, value, nodups=v1, priority=v2}
 function M.append_path(self, t)
-   local sep      = t.delim or ":"
+   local delim    = t.delim or ":"
    local name     = t[1]
    local value    = t[2]
    local nodups   = not allow_dups( not t.nodups)
@@ -488,7 +488,7 @@ function M.append_path(self, t)
    local varT     = frameStk:varT()
 
    dbg.start{"MasterControl:append_path{\"",name,"\", \"",value,
-             "\", delim=\"",sep,"\", nodups=\"",nodups,
+             "\", delim=\"",delim,"\", nodups=\"",nodups,
              "\", priority=",priority,
              "}"}
 
@@ -496,7 +496,7 @@ function M.append_path(self, t)
    nodups = name == ModulePath or nodups
 
    if (varT[name] == nil) then
-      varT[name] = Var:new(name, false, nodups, sep)
+      varT[name] = Var:new(name, false, nodups, delim)
    end
 
    varT[name]:append(tostring(value), nodups, priority)
@@ -508,7 +508,7 @@ end
 -- @param self A MasterControl object
 -- @param t A table containing { name, value, nodups=v1, priority=v2, where=v3, force=v4}
 function M.remove_path(self, t)
-   local sep      = t.delim or ":"
+   local delim    = t.delim or ":"
    local name     = t[1]
    local value    = t[2]
    local nodups   = not allow_dups( not t.nodups)
@@ -519,7 +519,7 @@ function M.remove_path(self, t)
    local force    = t.force
 
    dbg.start{"MasterControl:remove_path{\"",name,"\", \"",value,
-             "\", delim=\"",sep,"\", nodups=\"",nodups,
+             "\", delim=\"",delim,"\", nodups=\"",nodups,
              "\", priority=",priority,
              ", where=",where,
              ", force=",force,
@@ -529,7 +529,7 @@ function M.remove_path(self, t)
    nodups = (name == ModulePath) or nodups
 
    if (varT[name] == nil) then
-      varT[name] = Var:new(name,nil, nodups, sep)
+      varT[name] = Var:new(name,nil, nodups, delim)
    end
    varT[name]:remove(tostring(value), where, priority, nodups, force)
    dbg.fini("MasterControl:remove_path")

--- a/src/Var.lua
+++ b/src/Var.lua
@@ -137,12 +137,12 @@ local function l_extract(self, nodups)
    local imax          = 0
    local imin          = 1
    local pathA         = {}
-   local sep           = self.sep
+   local delim         = self.delim
    local priorityT     = l_extract_Lmod_var_table(self, envPrtyName)
    local refCountT     = l_extract_Lmod_var_table(self, envRefCountName)
 
    if (myValue and myValue ~= '') then
-      pathA = path2pathA(myValue, sep, clearDblSlash)
+      pathA = path2pathA(myValue, delim, clearDblSlash)
       for i,v in ipairs(pathA) do
          local vv       = pathTbl[v] or {num = -1, idxA = {}}
          local num      = vv.num
@@ -197,14 +197,14 @@ end
 -- @param name The name of the variable.
 -- @param value The value assigned to the variable.
 -- @param nodup If true then no duplicate entries in path like variable.
--- @param sep The separator character.  (By default it is ":")
-function M.new(self, name, value, nodup, sep)
+-- @param delim The delimiter character.  (By default it is ":")
+function M.new(self, name, value, nodup, delim)
    local o = {}
    setmetatable(o,self)
    self.__index = self
    o.value      = value
    o.name       = name
-   o.sep        = sep or ":"
+   o.delim      = delim or ":"
    if (name == ModulePath) then
       nodup = true
    end
@@ -275,7 +275,7 @@ function M.remove(self, value, where, priority, nodups, force)
 
    where = allow_dups(true) and where or "all"
    local clearDblSlash = self.name == "MODULEPATH"
-   local pathA   = path2pathA(value, self.sep, clearDblSlash)
+   local pathA   = path2pathA(value, self.delim, clearDblSlash)
    local tbl     = self.tbl
    local adding  = false
 
@@ -373,13 +373,13 @@ function M.prepend(self, value, nodups, priority)
    priority            = priority or 0
    local name          = self.name
    local clearDblSlash = name == "MODULEPATH"
-   local pathA         = path2pathA(value, self.sep, clearDblSlash)
+   local pathA         = path2pathA(value, self.delim, clearDblSlash)
    local is, ie, iskip = prepend_order(#pathA)
    local isPrepend     = true
    local adding        = true
-   local p2A           ={}
+   local p2A           = {}
 
-   local tbl  = self.tbl
+   local tbl = self.tbl
 
    local tracing  = cosmic:value("LMOD_TRACING")
    if (tracing == "yes" and name == ModulePath ) then
@@ -434,7 +434,7 @@ function M.append(self, value, nodups, priority)
    priority            = tonumber(priority or "0")
    local name          = self.name
    local clearDblSlash = name == "MODULEPATH"
-   local pathA         = path2pathA(value, self.sep, clearDblSlash)
+   local pathA         = path2pathA(value, self.delim, clearDblSlash)
    local isPrepend     = false
    local adding        = true
 
@@ -623,7 +623,7 @@ function M.expand(self)
    local t         = {}
    local pathA     = {}
    local pathStr   = false
-   local sep       = self.sep
+   local delim     = self.delim
    local prT       = {}
    local maxV      = max(abs(self.imin), self.imax) + 1
    local factor    = 10^ceil(log(maxV)*ln10_inv+1)
@@ -681,14 +681,14 @@ function M.expand(self)
       end
    end
 
-   -- Step 3: convert pathA array into "sep" separated string.
+   -- Step 3: convert pathA array into "delim" separated string.
    --         Also Handle "" at end of "path"
    if (n == 1 and pathA[1] == "") then
-      pathStr = sep .. sep
+      pathStr = delim .. delim
    else
-      pathStr = concatTbl(pathA,sep)
+      pathStr = concatTbl(pathA,delim)
       if (pathA[#pathA] == "") then
-         pathStr = pathStr .. sep
+         pathStr = pathStr .. delim
       end
    end
 

--- a/src/addto.in.lua
+++ b/src/addto.in.lua
@@ -167,7 +167,7 @@ function main()
    local masterTbl = masterTbl()
    local pargs     = masterTbl.pargs
    local cleanFlg  = masterTbl.cleanFlg
-   local sep       = masterTbl.sep
+   local delim     = masterTbl.delim
 
    local envVar    = os.getenv(pargs[1])
    local insert    = myInsert(masterTbl.appendFlg, masterTbl.existFlg)
@@ -228,7 +228,7 @@ function main()
       insert(newA, v)
    end
 
-   io.stdout:write(concat(newA,sep),"\n")
+   io.stdout:write(concat(newA,delim),"\n")
 end
 
 
@@ -273,11 +273,11 @@ function options()
    }
 
    cmdlineParser:add_option{
-      name   = {'--sep'},
-      dest   = 'sep',
+      name   = {'--sep', '--delim'},
+      dest   = 'delim',
       action = 'store',
       default = ":",
-      help    = "separator (default is ':')"
+      help    = "delimiter (default is ':')"
    }
 
    local optionTbl, pargs = cmdlineParser:parse(arg)

--- a/src/modfuncs.lua
+++ b/src/modfuncs.lua
@@ -71,8 +71,8 @@ local pack         = (_VERSION == "Lua 5.1") and argsPack or table.pack -- luach
 --------------------------------------------------------------------------
 -- Special table concat function that knows about strings and numbers.
 -- @param aa  Input array
--- @param sep output separator.
-local function concatTbl(aa,sep)
+-- @param delim output separator.
+local function concatTbl(aa,delim)
    if (not dbg.active()) then
       return ""
    end
@@ -88,7 +88,7 @@ local function concatTbl(aa,sep)
          a[i] = vType
       end
    end
-   return _concatTbl(a, sep)
+   return _concatTbl(a, delim)
 end
 
 --------------------------------------------------------------------------

--- a/src/sh_to_modulefile.in.lua
+++ b/src/sh_to_modulefile.in.lua
@@ -312,7 +312,7 @@ function path_regularize(value)
 end
 
 function path2pathA(path)
-   local sep = ":"
+   local delim = ":"
    if (not path) then
       return {}
    end
@@ -321,7 +321,7 @@ function path2pathA(path)
    end
 
    local pathA = {}
-   for v  in path:split(sep) do
+   for v  in path:split(delim) do
       pathA[#pathA + 1] = path_regularize(v)
    end
    return pathA

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -546,11 +546,11 @@ end
 -- To handle that, the path component is converted to
 -- a single space.  This single space is later removed
 -- when expanding.
--- @param path A string of *sep* separated paths.
--- @param sep  The separator character.  It is usually
---             a colon.
-function path2pathA(path, sep, clearDoubleSlash)
-   sep = sep or ":"
+-- @param path A string of *delim* separated paths.
+-- @param delim  The separator character.  It is usually
+--               a colon.
+function path2pathA(path, delim, clearDoubleSlash)
+   delim = delim or ":"
    if (not path) then
       return {}
    end
@@ -561,7 +561,7 @@ function path2pathA(path, sep, clearDoubleSlash)
    local is, ie
 
    local pathA = {}
-   for v  in path:split(sep) do
+   for v  in path:split(delim) do
       local path = path_regularize(v)
       if (clearDoubleSlash) then
          path = path:gsub("//+" , "/")


### PR DESCRIPTION
Basically all sep named variables has been
changed to delim. Only a few places (string_utils) are
they unchanged since it doesn't really affect the Lmod
base as much.

This is just to clarify for developers a coherence between
the documentation and the implementation.

I have also added another cmd argument with --delim
which behaves similar to --sep.