### PR TITLE
Fix overview help typos (and try translation)

### DIFF
--- a/rt/help/err.txt
+++ b/rt/help/err.txt
@@ -61,7 +61,7 @@ Listing / Searching sub-commands:
   avail | av                        List available modules
   avail | av          string        List available modules that contain "string".
   overview | ov                     List all available modules by short names with number of versions
-  overview | av       string        List available modules by short names with number of versions that contain "string"
+  overview | ov       string        List available modules by short names with number of versions that contain "string"
   spider                            List all possible modules
   spider              module        List all possible version of that module file
   spider              string        List all module that contain the "string".
@@ -162,7 +162,7 @@ Listing / Searching sub-commands:
   avail | av                        List available modules
   avail | av          string        List available modules that contain "string".
   overview | ov                     List all available modules by short names with number of versions
-  overview | av       string        List available modules by short names with number of versions that contain "string"
+  overview | ov       string        List available modules by short names with number of versions that contain "string"
   spider                            List all possible modules
   spider              module        List all possible version of that module file
   spider              string        List all module that contain the "string".

--- a/rt/i18n/err.txt
+++ b/rt/i18n/err.txt
@@ -102,8 +102,8 @@ Sous-commandes pour lister / chercher :
   list                s1 s2 ...     Liste les modules chargés qui correspondent à la recherche
   avail | av                        Liste les modules disponibles
   avail | av          string        Liste les modules disponibles qui contiennent "string".
-  overview | ov                     List all available modules by short names with number of versions
-  overview | av       string        List available modules by short names with number of versions that contain "string"
+  overview | ov                     Liste tous les modules disponibles par noms courts avec nombre de versions
+  overview | ov       string        Liste les modules disponibles par noms courts avec nombre de versions qui contiennent "string"
   spider                            Liste tous les modules existants
   spider              module        Liste toutes les versions d'un module
   spider              string        Liste tous les modules qui contiennent "string".

--- a/src/lmod.in.lua
+++ b/src/lmod.in.lua
@@ -166,7 +166,7 @@ function Usage()
    a[#a+1] = { "  avail | av",    "",             i18n("list3")  }
    a[#a+1] = { "  avail | av",    "string",       i18n("list4")  }
    a[#a+1] = { "  overview | ov", "",             i18n("ov1")    }
-   a[#a+1] = { "  overview | av", "string",       i18n("ov2")    }
+   a[#a+1] = { "  overview | ov", "string",       i18n("ov2")    }
    a[#a+1] = { "  spider",        "",             i18n("list5")  }
    a[#a+1] = { "  spider",        "module",       i18n("list6")  }
    a[#a+1] = { "  spider",        "string",       i18n("list7")  }


### PR DESCRIPTION
I noticed today that `module help` said:
```
  overview | ov                     List all available modules by short names with number of versions
  overview | av       string        List available modules by short names with number of versions that contain "string"
```
and I figured that should be an `ov` on the second line.

After fixing those up, I also decided to try my hand at doing a French translation in `rt/i18n/err.txt`. My baby-level-on-Duolingo and Google Translate attempt is contained herein.