### PR TITLE
fix building of Lmod documentation on ReadTheDocs by pinning to old Sphinx/docutils version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,19 @@
+# .readthedocs.yml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# version of configuration file (required)
+version: 2
+
+# Build from the docs/ directory with Sphinx
+sphinx:
+  configuration: docs/source/conf.py
+
+# also build docs in PDF format
+formats: [pdf]
+
+# Optionally set the version of Python and requirements required to build your docs
+python:
+  version: 3.7
+  install:
+      - requirements: docs/requirements.txt

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+docutils<0.18
+sphinx==1.8.5


### PR DESCRIPTION
Lmod docs build for `master` branch is failing currently, see https://readthedocs.org/projects/lmod/builds/15214716/.

The problem is caused by a mismatch between Sphinx 1.8.5 (which is *old*) and latest docutils, see https://github.com/readthedocs/readthedocs.org/issues/8616, https://github.com/sphinx-doc/sphinx/issues/9811 and https://github.com/sphinx-doc/sphinx/issues/9783, among others.   

The problem only occurs for old project on ReadTheDocs, which still default to `sphinx<2`; see https://docs.readthedocs.io/en/stable/builds.html#python .

The proposed change is the easy way out, by pinning to an old `docutils` version that is compatible with Sphinx 1.8.5 (most recent Sphinx version < 2).

A better long-term approach would be to pin to a more recent version of Sphinx (and perhaps also docutils), since building the Lmod documentation with the currently latest version of Sphinx (4.2.0) seems to be working fine too; see also https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html .

cc @wpoely86