### PR TITLE
reload_sticky in reverse order to match load order on purge

### DIFF
--- a/src/Master.lua
+++ b/src/Master.lua
@@ -775,7 +775,7 @@ function M.reload_sticky(self, force)
    local mcp_old  = mcp
    mcp            = MCP
    local reload   = false
-   for i = 1, #stickyA do
+   for i = #stickyA, 1, -1 do
       local entry = stickyA[i]
       local mname = MName:new("load",entry.userName)
       local fn    = mname:fn()


### PR DESCRIPTION
We have nested sticky modules, which is to say, module A adds a module path containing module B, both of which are sticky.  If you load A and B, and then `module purge`, you end up with only module A loaded, and B not.  This is because the modules are unloaded in reverse order (B, A), and added to the sticky list in this order, and thus reloaded in this order: B (not found, since it's under A), then A.  Reversing the reload order in `reload_sticky` seems to fix this.  (Could also add them to stickyA in reverse order but this seems easier.