### PR TITLE
Quote code generated by lmod cmd to pass it to eval

### DIFF
--- a/init/bash.in
+++ b/init/bash.in
@@ -93,7 +93,7 @@ if [ "@silence_shell_debugging@" = "no" ]; then
 
      ############################################################
      # Run Lmod and eval results
-     eval $($LMOD_CMD @my_shell@ "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
+     eval "$($LMOD_CMD @my_shell@ "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
      __lmod_my_status=$?
 
      ############################################################
@@ -135,7 +135,7 @@ else
 
      ############################################################
      # Run Lmod and eval results
-     eval $($LMOD_CMD @my_shell@ "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
+     eval "$($LMOD_CMD @my_shell@ "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
      __lmod_my_status=$?
 
      ############################################################
@@ -179,7 +179,7 @@ fi
 unalias ml 2> /dev/null || true
 ml()
 {
-  eval $($LMOD_DIR/ml_cmd "$@")
+  eval "$($LMOD_DIR/ml_cmd "$@")"
 }
 
 if [ -n "${BASH_VERSION:-}" -a "@export_module@" != no ]; then

--- a/init/ksh_funcs/ml
+++ b/init/ksh_funcs/ml
@@ -5,7 +5,7 @@
 if [ -n "${KSH_VERSION+x}" ]; then
    ml ()
    {
-     eval $($LMOD_DIR/ml_cmd "$@")
+     eval "$($LMOD_DIR/ml_cmd "$@")"
    }
 fi
 

--- a/init/ksh_funcs/module
+++ b/init/ksh_funcs/module
@@ -6,7 +6,7 @@ if [ -n "${KSH_VERSION+x}" ]; then
   if [ "@silence_shell_debugging@" = "no" ]; then
      module()
      {
-       eval $($LMOD_CMD ksh "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
+       eval "$($LMOD_CMD ksh "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
      }
   else
      module()
@@ -26,7 +26,7 @@ if [ -n "${KSH_VERSION+x}" ]; then
           echo "Shell debugging temporarily silenced: export LMOD_SH_DBG_ON=1 for Lmod's output" 1>&2
        fi
 
-       eval $($LMOD_CMD ksh "$@") && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
+       eval "$($LMOD_CMD ksh "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)
        __lmod_my_status=$?
 
        ############################################################

--- a/init/sh.in
+++ b/init/sh.in
@@ -12,7 +12,7 @@ export MODULESHOME
 
 module()
 {
-  eval `$LMOD_CMD sh "$@"`
+  eval "`$LMOD_CMD sh "$@"`"
 }
 
 clearMT()
@@ -29,7 +29,7 @@ clearMT()
 #  It does much more do: "ml --help" for more information.
 ml()
 {
-  eval $($LMOD_DIR/ml_cmd "$@")
+  eval "$($LMOD_DIR/ml_cmd "$@")"
 }
 
 # Local Variables:


### PR DESCRIPTION
A more generic solution to the pathname expansion issue (fixed for Bash
with the use of set -f/set +f) is to quote the code generated as output
by the 'lmod' command to pass it to the shell 'eval' command.

The pathname expansion issue also affects ksh93 and bash-variant of sh
shells. Quoting generated code in the module/ml shell functions of these
shells will help here too.

This change was just applied on Modules and from the tests made, I have
seen that it also fix some script shell evaluations performed through
source-sh.

With this change, the set -f/set +f code applied around lmod command
execution in module bash shell function could be removed. Which will
help to fix #569.