### PR TITLE
Fix function call in serializeTbl()

### DIFF
--- a/tools/serializeTbl.lua
+++ b/tools/serializeTbl.lua
@@ -250,7 +250,7 @@ function serializeTbl(options)
    else
       a[#a+1] = wrap_name("",n)
       a[#a+1] = " = "
-      a[#a+1] = nsformat(value)
+      a[#a+1] = l_nsformat(value)
       a[#a+1] = "\n"
    end
 


### PR DESCRIPTION
We wrote some code that makes use of serializeTbl( ) and stumbled upon this little (I presume) typo. It's minor but I felt it was worth fixing it upstream.