### PR TITLE
Add sub-command category

### DIFF
--- a/src/Hook.lua
+++ b/src/Hook.lua
@@ -62,6 +62,7 @@ local validT =
                                     -- to moduleT.lua to make it safe on
                                     -- shared filesystems.
       avail                = false, -- Map directory names to labels
+      category             = false, -- Hook to change output of category
       restore              = false, -- This hook is run after restore operation
       startup              = false, -- This hook is run when Lmod is called
       finalize             = false, -- This hook is run just before Lmod generates its output before exiting

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -197,7 +197,37 @@ To get a list of every module in a category execute:
       end
       a[#a+1] = "\n"
    else
+      local argA = pack(...)
+      local searchA = {}
+
+      for i = 1, argA.n do
+         searchA[i] = argA[i]:caseIndependent()
+      end
+      searchA.n = argA.n
+
+      local match = {}
+
       for cat, v in pairsByKeys(categoryT) do
+         for i = 1, searchA.n do
+            if (cat:find(searchA[i])) then
+               match[cat] = v
+            end
+         end
+      end
+
+      a[#a+1] = "\n"
+      a[#a+1] = [[
+To learn more about a package and how to load it execute:
+   $ module spider Bar
+      ]]
+
+      if (next(match) == nil) then
+         a[#a+1] = "\n"
+         a[#a+1] = "No matching category found."
+         a[#a+1] = "\n"
+      end
+
+      for cat, v in pairsByKeys(match) do
          local b = {}
 
          for sn, count in pairsByKeys(v) do

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -180,21 +180,11 @@ function Category(...)
 
    local a = {}
 
-   local function get_sorted_keys(tbl)
-      local s = {}
-      for k, v in pairs(tbl) do s[#s+1] = k end
-      sort(s)
-      return s
-   end
-
-   local categoryA = get_sorted_keys(categoryT)
-
-   for _, cat in ipairs(categoryA) do
+   for cat, v in pairsByKeys(categoryT) do
       local b = {}
-      local keysA = get_sorted_keys(categoryT[cat])
 
-      for _, sn in ipairs(keysA) do
-         b[#b+1] = { sn, "(" .. tostring(categoryT[cat][sn]) .. ")  " }
+      for sn, count in pairsByKeys(v) do
+         b[#b+1] = { sn, "(" .. tostring(count) .. ")  " }
       end
 
       dbg.print{"printing category block\n"}

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -192,9 +192,18 @@ To get a list of every module in a category execute:
       a[#a+1] = "\n"
       a[#a+1] = banner:bannerStr("List of Categories")
       a[#a+1] = "\n"
+
+      local b = {}
       for cat, _ in pairsByKeys(categoryT) do
-         a[#a+1] = cat .. "\n"
+         b[#b+1] = cat .. "\n"
       end
+
+      b = hook.apply("category", "simple", b) or b
+
+      for i = 1, #b do
+         a[#a+1] = b[i]
+      end
+
       a[#a+1] = "\n"
    else
       local argA = pack(...)
@@ -205,12 +214,14 @@ To get a list of every module in a category execute:
       end
       searchA.n = argA.n
 
-      local match = {}
+      local match = hook.apply("category", "complex", categoryT) or {}
 
-      for cat, v in pairsByKeys(categoryT) do
-         for i = 1, searchA.n do
-            if (cat:find(searchA[i])) then
-               match[cat] = v
+      if (next(match) == nil) then
+         for cat, v in pairsByKeys(categoryT) do
+            for i = 1, searchA.n do
+               if (cat:find(searchA[i])) then
+                  match[cat] = v
+               end
             end
          end
       end

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -142,6 +142,7 @@ function Category(...)
    dbg.start{"Category(", concatTbl({...},", "),")"}
    local shell = _G.Shell
 
+
    local cache = Cache:singleton{buildCache = true}
    local moduleT, dbT = cache:build()
 
@@ -174,26 +175,43 @@ function Category(...)
    end
 
    local masterTbl = masterTbl()
+   local search = ... and true
    local twidth = TermWidth()
    local cwidth = masterTbl.rt and LMOD_COLUMN_TABLE_WIDTH or twidth
    local banner = Banner:singleton()
 
    local a = {}
 
-   for cat, v in pairsByKeys(categoryT) do
-      local b = {}
-
-      for sn, count in pairsByKeys(v) do
-         b[#b+1] = { sn, "(" .. tostring(count) .. ")  " }
-      end
-
+   if (not search) then
       dbg.print{"printing category block\n"}
-      local ct = ColumnTable:new{tbl = b, gap = 1, len = length, width = cwidth}
       a[#a+1] = "\n"
-      a[#a+1] = banner:bannerStr(cat)
+      a[#a+1] = [[
+To get a list of every module in a category execute:
+   $ module category Foo
+      ]]
       a[#a+1] = "\n"
-      a[#a+1] = ct:build_tbl()
+      a[#a+1] = banner:bannerStr("List of Categories")
       a[#a+1] = "\n"
+      for cat, _ in pairsByKeys(categoryT) do
+         a[#a+1] = cat .. "\n"
+      end
+      a[#a+1] = "\n"
+   else
+      for cat, v in pairsByKeys(categoryT) do
+         local b = {}
+
+         for sn, count in pairsByKeys(v) do
+            b[#b+1] = { sn, "(" .. tostring(count) .. ")  " }
+         end
+
+         dbg.print{"printing category block\n"}
+         local ct = ColumnTable:new{tbl = b, gap = 1, len = length, width = cwidth}
+         a[#a+1] = "\n"
+         a[#a+1] = banner:bannerStr(cat)
+         a[#a+1] = "\n"
+         a[#a+1] = ct:build_tbl()
+         a[#a+1] = "\n"
+      end
    end
 
    if (next(a) ~= nil) then

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -231,6 +231,7 @@ where "Foo" is the name of a category.
       a[#a+1] = [[
 To learn more about a package and how to load it execute:
    $ module spider Bar
+where "Bar" is the name of a package.
       ]]
 
       if (next(match) == nil) then

--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -188,6 +188,7 @@ function Category(...)
       a[#a+1] = [[
 To get a list of every module in a category execute:
    $ module category Foo
+where "Foo" is the name of a category.
       ]]
       a[#a+1] = "\n"
       a[#a+1] = banner:bannerStr("List of Categories")

--- a/src/lmod.in.lua
+++ b/src/lmod.in.lua
@@ -165,6 +165,7 @@ function Usage()
    a[#a+1] = { "  list",          "s1 s2 ...",    i18n("list2")  }
    a[#a+1] = { "  avail | av",    "",             i18n("list3")  }
    a[#a+1] = { "  avail | av",    "string",       i18n("list4")  }
+   a[#a+1] = { "  category | cat","",             "List all categories and their modules" }
    a[#a+1] = { "  overview | ov", "",             i18n("ov1")    }
    a[#a+1] = { "  overview | ov", "string",       i18n("ov2")    }
    a[#a+1] = { "  spider",        "",             i18n("list5")  }
@@ -276,10 +277,12 @@ function main()
    local whatisTbl    = { name = "whatis",      checkMPATH = false, cmd = Whatis        }
    local isLoadedTbl  = { name = "isLoaded",    checkMPATH = false, cmd = IsLoaded      }
    local isAvailTbl   = { name = "isAvail",     checkMPATH = false, cmd = IsAvail       }
+   local categoryTbl  = { name = "category",    checkMPATH = true,  cmd = Category      }
 
    local lmodCmdA = {
       {cmd = 'add',          min = 2, action = loadTbl     },
       {cmd = 'avail',        min = 2, action = availTbl    },
+      {cmd = 'category',     min = 3, action = categoryTbl },
       {cmd = 'delete',       min = 3, action = unloadTbl   },
       {cmd = 'describe',     min = 3, action = mcTbl       },
       {cmd = 'disable',      min = 4, action = disableTbl  },

--- a/src/lmod.in.lua
+++ b/src/lmod.in.lua
@@ -165,7 +165,8 @@ function Usage()
    a[#a+1] = { "  list",          "s1 s2 ...",    i18n("list2")  }
    a[#a+1] = { "  avail | av",    "",             i18n("list3")  }
    a[#a+1] = { "  avail | av",    "string",       i18n("list4")  }
-   a[#a+1] = { "  category | cat","",             "List all categories and their modules" }
+   a[#a+1] = { "  category | cat","",             "List all categories" }
+   a[#a+1] = { "  category | cat","s1 s2 ...",    "List all categories that match the pattern and display their modules" }
    a[#a+1] = { "  overview | ov", "",             i18n("ov1")    }
    a[#a+1] = { "  overview | ov", "string",       i18n("ov2")    }
    a[#a+1] = { "  spider",        "",             i18n("list5")  }

--- a/src/ml_cmd.in.lua
+++ b/src/ml_cmd.in.lua
@@ -180,6 +180,7 @@ function main()
 
    local lmodCmdT = {
       avail="avail",  av="avail", available="avail",
+      category="category", cat="category",
       describe="describe", mcc="describe",
       disable="disable",
       getdefault="getdefault", gd="getdefault",


### PR DESCRIPTION
The commit adds the sub-command `category | cat` which works similar to `overview` but instead lists modules under the categories they are part of and looks at every module reported by Cache.

As Robert mentioned on the mailing list I used the Category entry that is being provided by `whatis("Category: Tools, Develop")`.

Missing are translations for the help page that should be used in [src/lmod.in.lua](https://github.com/TACC/Lmod/compare/master...d-kirsten:Lmod:category#diff-4d5704e39b887757ed4e5c7e4651c7e242d5e9c5632b069e09f1901e30293ed5) line 168.

Please let me know if I should make changes to the code.