### PR TITLE
Fix ml to accept option '--config_json' as does module

### DIFF
--- a/src/ml_cmd.in.lua
+++ b/src/ml_cmd.in.lua
@@ -157,7 +157,7 @@ function main()
       ["--version"]=0,  ["--versoin"]=0, ["--ver"]=0, ["--v"]=0, ["-v"]=0,
       ['--config'] = 0,
       ['--miniConfig'] = 0,
-      ['--config-json'] = 0,
+      ['--config_json'] = 0, ['--config-json'] = 0,
       ['--raw'] = 0,
       ['--regexp'] = 0, ['-r'] = 0,
       ['--show_hidden'] = 0, ['--show-hidden'] = 0,


### PR DESCRIPTION
The '--config-json' option was renamed to '--config_json' for 'module' in f3f1ac84993f1d5b630fcfcd5f60aa52d7bdaea7
but not in 'ml'.