### PR TITLE
colorize the version numbers in `ml av` with env. var.

### DIFF
--- a/src/utils.lua
+++ b/src/utils.lua
@@ -264,7 +264,7 @@ function colorizePropA(style, modT, mrc, propT, legendT)
    local version = extractVersion(modT.fullName, modT.sn)
    local version_color = getenv("LMOD_AVAIL_VERSION_COLOR")
    -- colorize() will use `plain` if `color` is not found in `colorT`
-   local moduleName = modT.sn.."/"..colorize(version_color, version)
+   local moduleName = modT.sn..colorize("/"..version_color, version)
    
    if (not mrc:isVisible(modT)) then
       local i18n = require("i18n")

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -259,9 +259,13 @@ function colorizePropA(style, modT, mrc, propT, legendT)
    local propDisplayT = readLmodRC:propT()
    local iprop        = 0
    local pA           = {}
-   local moduleName   = modT.fullName
    propT              = propT or {}
 
+   local version = extractVersion(modT.fullName, modT.sn)
+   local version_color = getenv("LMOD_AVAIL_VERSION_COLOR")
+   -- colorize() will use `plain` if `color` is not found in `colorT`
+   local moduleName = modT.sn.."/"..colorize(version_color, version)
+   
    if (not mrc:isVisible(modT)) then
       local i18n = require("i18n")
       local H    = 'H'


### PR DESCRIPTION
https://github.com/tacc/lmod/issues/603