### PR TITLE
-f as alias for --force in module command

### DIFF
--- a/src/Options.lua
+++ b/src/Options.lua
@@ -305,7 +305,7 @@ function M.singleton(self, usage)
    }
 
    cmdlineParser:add_option{
-      name   = {"--force" },
+      name   = {"-f","--force"},
       dest   = "force",
       action = "store_true",
       help   = i18n("force_hlp"),


### PR DESCRIPTION
In 8.7.25 the option -f was introduced as alias for --force in the ml command. Now updating Options.lua to make the module command consistent again.