### PR TITLE
Do not use install to copy symbolic links

### DIFF
--- a/pkgs/tcl2lua/Makefile
+++ b/pkgs/tcl2lua/Makefile
@@ -25,7 +25,9 @@ $(LIBRARY): $(OBJ)
 	$(CC) $(CFLAGS) $(LIB_OPTION) -o $(LIBRARY) $(OBJ) $(LDFLAGS) -lc $(LIBS) $(TCL_LIBS)
 
 install: all
-	install -m $(MODE_R) *.so* $(LIB)
+	install -m $(MODE_R) $(LIBRARY) $(LIB)
+	ln -s $(LIBRARY) $(LIB)/$(SONAMEV)
+	ln -s $(SONAMEV) $(LIB)/$(SONAME)
 
 clean:	neat
 	$(RM) $(LIBRARY) $(SONAMEV) $(SONAME)


### PR DESCRIPTION
install will dereference symbolic links.

On a somewhat related question - will it cause problems if I install tcl2lua.so* to a different location?  What uses it and how to test?  Thanks.