### PR TITLE
doc: fix `info exists` Tcl example in FAQ

### DIFF
--- a/docs/source/040_FAQ.rst
+++ b/docs/source/040_FAQ.rst
@@ -236,8 +236,7 @@ and Tmod?
   You can prevent Tmod from executing Lmod only code in the following way::
 
     #%Module
-    global env
-    if { [info exists $env(LMOD_VERSION_MAJOR)]} {
+    if { [info exists ::env(LMOD_VERSION_MAJOR)] } {
        hide-version CUDA/8.8.8
     }
 
@@ -247,8 +246,7 @@ and Tmod?
 
     #%Module
     ...
-    global env
-    if { [info exists $env(LMOD_VERSION_MAJOR)]} {
+    if { [info exists ::env(LMOD_VERSION_MAJOR)] } {
        family compiler
     }
 


### PR DESCRIPTION
Variable name (i.e., `::env(LMOD_VERSION_MAJOR)`) should be used against `info exists` Tcl command to check variable existence rather variable value (i.e., `$::env(LMOD_VERSION_MAJOR)`), which will raise an error if variable does not exist.