### PR TITLE
Update 030_installing.rst

### DIFF
--- a/docs/source/030_installing.rst
+++ b/docs/source/030_installing.rst
@@ -120,6 +120,7 @@ to work you may need to repair your /etc/apt/sources.list.  Check to
 see if your sources.list file as uncommmented "deb-src" lines.  Once
 this is correct, please execute the following lines::
 
+    $ sudo apt update
     $ sudo apt -y build-dep lmod
     $ lua_ver=$(which lua | xargs realpath -e | xargs basename)
     $ sudo apt -y install lib${lua_ver}-dev tcl-dev


### PR DESCRIPTION
On the Debian-based systems (Ubuntu 20.04.6 LTS in my case) one has to update package information after modyfing `/etc/apt/sources.list` file.