### PR TITLE
Add simple `JsonShell`

### DIFF
--- a/shells/BaseShell.lua
+++ b/shells/BaseShell.lua
@@ -292,6 +292,7 @@ local function l_createShellTbl()
       local Lisp         = require('Lisp')
       local Perl         = require('Perl')
       local Python       = require('Python')
+      local Json         = require('JsonShell')
       local R            = require('R')
       local Rc           = require('Rc')
       local Ruby         = require('Ruby')
@@ -310,6 +311,7 @@ local function l_createShellTbl()
          ["tcsh"]   = {name = "tcsh",   object = Csh    },
          ["perl"]   = {name = "perl",   object = Perl   }, 
          ["python"] = {name = "python", object = Python },
+         ["json"]   = {name = "json",   object = Json   },
          ["cmake"]  = {name = "cmake",  object = CMake  },
          ["bare"]   = {name = "bare",   object = Bare   },
          ["r"]      = {name = "r",      object = R      },

--- a/shells/JsonShell.lua
+++ b/shells/JsonShell.lua
@@ -50,29 +50,37 @@ Json.my_name    = "json"
 Json.myType     = Json.my_name
 Json.js         = ""
 
+function Json.initialize(self)
+   -- Empty the json script so that it can be used in individual --
+   self.js = json.encode({alias={}, shellFunc={}, env={}, unset={}})
+end
+
 function Json.alias(self, k, v)
-   -- do nothing: everything is handled in expand
+   local tbl = js.decode(self.js)
+   tbl["alias"][k] = v
+   self.js = js.encode(tbl)
 end
 
 function Json.shellFunc(self, k, v)
-   -- do nothing: everything is handled in expand
+   local tbl = js.decode(self.js)
+   tbl["shellFunc"][k] = v
+   self.js = js.encode(tbl)
 end
 
 function Json.expandVar(self, k, v, vType)
-   -- do nothing: everything is handled in expand
+   local tbl = js.decode(self.js)
+   tbl["env"][k] = v
+   self.js = js.encode(tbl)
 end
 
 function Json.unset(self, k, vType)
-   -- do nothing: everything is handled in expand
+   local tbl = js.decode(self.js)
+   tbl["unset"][#tbl["unset"]+1] = k
+   self.js = js.encode(tbl)
 end
 
 function Json.echo(self,...)
    self:_echo(...)
-end
-
-function Json.expand(self, tbl)
-   self.js = js.encode(tbl)
-   BaseShell.expand(self, tbl)
 end
 
 function Json.report_failure(self)
@@ -85,7 +93,7 @@ function Json.report_success(self)
    local report = js.decode(self.js)
    report["_mlstatus"] = true
    stdout:write(js.encode(report))
-   dbg.print{   self.js}
+   dbg.print{self.js}
 end
 
 return Json

--- a/shells/JsonShell.lua
+++ b/shells/JsonShell.lua
@@ -1,0 +1,91 @@
+--------------------------------------------------------------------------
+-- Lmod License
+--------------------------------------------------------------------------
+--
+--  Lmod is licensed under the terms of the MIT license reproduced below.
+--  This means that Lmod is free software and can be used for both academic
+--  and commercial purposes at absolutely no cost.
+--
+--  ----------------------------------------------------------------------
+--
+--  Copyright (C) 2008-2018 Robert McLay
+--
+--  Permission is hereby granted, free of charge, to any person obtaining
+--  a copy of this software and associated documentation files (the
+--  "Software"), to deal in the Software without restriction, including
+--  without limitation the rights to use, copy, modify, merge, publish,
+--  distribute, sublicense, and/or sell copies of the Software, and to
+--  permit persons to whom the Software is furnished to do so, subject
+--  to the following conditions:
+--
+--  The above copyright notice and this permission notice shall be
+--  included in all copies or substantial portions of the Software.
+--
+--  THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
+--  EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
+--  OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
+--  NONINFRINGEMENT.  IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS
+--  BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN
+--  ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+--  CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+--  THE SOFTWARE.
+--
+--------------------------------------------------------------------------
+
+--------------------------------------------------------------------------
+-- Json(): This is a derived class from BaseShell.  It outputs the lua table
+--         as a json object
+
+require("strict")
+
+local js        = require("json")
+
+local BaseShell = require("BaseShell")
+local Json      = inheritsFrom(BaseShell)
+local dbg       = require("Dbg"):dbg()
+local Var       = require("Var")
+local concatTbl = table.concat
+local stdout    = io.stdout
+Json.my_name    = "json"
+Json.myType     = Json.my_name
+Json.js         = ""
+
+function Json.alias(self, k, v)
+   -- do nothing: everything is handled in expand
+end
+
+function Json.shellFunc(self, k, v)
+   -- do nothing: everything is handled in expand
+end
+
+function Json.expandVar(self, k, v, vType)
+   -- do nothing: everything is handled in expand
+end
+
+function Json.unset(self, k, vType)
+   -- do nothing: everything is handled in expand
+end
+
+function Json.echo(self,...)
+   self:_echo(...)
+end
+
+function Json.expand(self, tbl)
+   self.js = js.encode(tbl)
+   BaseShell.expand(self, tbl)
+end
+
+function Json.report_failure(self)
+   local js_txt = js.encode({_mlstatus=false})
+   stdout:write(js_txt)
+   dbg.print{   js_txt}
+end
+
+function Json.report_success(self)
+   local report = js.decode(self.js)
+   report["_mlstatus"] = true
+   stdout:write(js.encode(report))
+   dbg.print{   self.js}
+end
+
+return Json

--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -1,4 +1,4 @@
-#!/usr/bin/env tclsh
+#!/usr/bin/tclsh
 
 #------------------------------------------------------------------------
 # Lmod License
@@ -39,8 +39,8 @@ global g_moduleT g_setup_moduleT g_lua_cmd env g_my_cmd
 global g_envT g_envClrT
 
 set g_setup_moduleT 0
-set g_lua_cmd       "@path_to_lua@"
-set g_lmod_cmd      "@path_to_lmod@"
+set g_lua_cmd       "/usr/bin/lua"
+set g_lmod_cmd      "/usr/share/lmod/8.7.31/libexec/lmod"
 set g_my_cmd        $argv0
 set g_envT          [dict create]
 set g_envClrT       [dict create]
@@ -1180,6 +1180,9 @@ switch -regexp -- $g_shellName {
     }
     ^(python)$ {
 	set g_shellType python
+    }
+    ^(json)$ {
+	set g_shellType json
     }
     ^(lisp)$ {
 	set g_shellType lisp


### PR DESCRIPTION
Adapted the python shell to make a simple json reporter.

Analyzing how this implementation behaves shows a few issues:
- The reported json object represents only the actions, not the current state of the module. So then what should the json interface report:
  - Specific actions of `set`/`unset`/`shell_function` etc. as specific keys to the json object? Then the consumer would have to keep track of the state of the environment variables setting/unsetting/updating
  - Expand the base table in the lua script and just output the final state
- Commands like `module list` do not produce a meaningful `tbl` to be exported as json