### PR TITLE
Allow registering multiple hooks of the same type

### DIFF
--- a/src/Hook.lua
+++ b/src/Hook.lua
@@ -81,7 +81,8 @@ local validT =
 --------------------------------------------------------------------------
 -- Checks for a valid hook name and stores it if valid.
 -- @param name The name of the hook.
--- @param func The function to store with it.
+-- @param func The function to store with it. This function is append if func is a table (of functions).
+-- Otherwise, it overwrites the currently registered hook.
 function M.register(name, func)
    if (validT[name] ~= nil) then
       -- If func is a table and validT[name] was previously set, append func to the current table. 
@@ -99,50 +100,15 @@ function M.register(name, func)
    end
 end
 
-function M.register_alt(name, func, append)
-  if (validT[name] ~= nil) then
-      -- set default for append to be backwards compatible
-      append = append or false
-      -- if append and validT[name] was set before, append. Otherwise, overwrite.
-      if append and validT[name] then
-         -- if validT[name] was set before (i.e. isn't false), append
-         validT[name][#validT[name]+1] = func
-      else
-         validT[name] = {func}
-      end
-   else
-      LmodWarning{msg="w_Unknown_Hook",name = tostring(name)}
-   end
-end
-
 --------------------------------------------------------------------------
 -- If a valid hook function has been registered then apply it.
 -- @param name The name of the hook.
 -- @return the results of the hook if it exists.
 function M.apply(name, ...)
    if (validT[name]) then
-      LmodMessage("Running apply hook "..name.." with table input of length "..#validT[name])
-      -- not entirely sure what the most sensible thing is to return here.
-      -- I would like it to be an array of return values, but arrays cant hold nil as a value...
-      -- The result is that the returned table might have fewer elements than the original hooks
-      -- That's... awkward, but could be done like this:
-      --
-      -- local returnT = {}
-      -- for i=1,#validT[name] do
-      --    local return_val = validT[name][i](...)
-      --    if return_val ~= nil then
-      --       table.insert(returnT, return_val)
-      --    end
-      -- end
-      -- return returnT
-      --
-      -- I prefer the alternative: just dont return anything.
-      -- That does not allow handling of any return values, but sensible handling of
-      -- arbitrary hook functions is hard anyway (we don't know the meaning of any return type)
       for i=1,#validT[name] do
          validT[name][i](...)
       end
-      return
    end
 end
 


### PR DESCRIPTION
Note: there is an alternative approach in [another PR](https://github.com/TACC/Lmod/pull/696) that I consider cleaner than the one in this PR (#695).

This PR stores hooks in `Hook.lua` internally as tables. It also adds the additional possibility of appending hooks to this table: if the argument passed to `hook.register` is a table, it gets appended. If it is a single function, it overwrites what was there. @rtmclay I'm not 100% sure if this is what you meant yesterday in the call by providing an alternative interface, but this was my understanding - if not, feel free to correct me.

It can be tested with this simple `SitePackage.lua`:

```
require("strict")
local hook = require("Hook")

local function load_hook_a(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Load hook A called on " .. simpleName)
end

local function load_hook_b(t)
    local frameStk  = require("FrameStk"):singleton()
    local mt        = frameStk:mt()
    local simpleName = string.match(t.modFullName, "(.-)/")
    LmodMessage("Load hook B called on " .. simpleName)
end

-- hook.register("load", combined_load_hook)
hook.register("load", load_hook_a)
hook.register("load", load_hook_b) -- overwrites previous hook, because the argument is not a table
hook.register("load", {load_hook_a}) -- appends the hook, as the argument is a table
hook.register("load", {load_hook_b}) -- appends the hook, as the argument is a table
```

I made this PR since I think it most closely matches what @rtmclay meant yesterday in the call. However, I feel the alternative PR is cleaner in terms of code, and I prefer that it is a more explicit approach.

Anyway, those are my 2 cents, curious to hear what you think.