### PR TITLE
Allow to override build date with SOURCE_DATE_EPOCH

### DIFF
--- a/proj_mgmt/DATE_cmd.sh
+++ b/proj_mgmt/DATE_cmd.sh
@@ -9,7 +9,6 @@ if [ $osType = "Darwin" ]; then
   if type -p gdate > /dev/null 2>&1; then
     my_cmd=gdate
   else
-    my_cmd=date
     arg="${arg%% %:z}"
   fi
 fi

--- a/proj_mgmt/DATE_cmd.sh
+++ b/proj_mgmt/DATE_cmd.sh
@@ -13,5 +13,8 @@ if [ $osType = "Darwin" ]; then
   fi
 fi
 
-$my_cmd "$arg"
+SOURCE_DATE_EPOCH="${SOURCE_DATE_EPOCH:-$($my_cmd +%s)}"
+$my_cmd -d "@$SOURCE_DATE_EPOCH" "$arg" 2>/dev/null ||
+  $my_cmd -r "$SOURCE_DATE_EPOCH" "$arg" 2>/dev/null ||
+  $my_cmd "$arg"
 


### PR DESCRIPTION
Allow to override build date with `SOURCE_DATE_EPOCH` to make builds reproducible.

See https://reproducible-builds.org/ for why this is good
and https://reproducible-builds.org/specs/source-date-epoch/ for the definition of this variable.

This date call works with different variants of date (GNU, FreeBSD, ...).

Also use UTC to be independent of timezone.

This patch was done while working on reproducible builds for openSUSE.