### PR TITLE
don't reference somebody else's fork

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -42,7 +42,7 @@ RUN apt-get update \
     
 
 RUN mkdir /tmp/git-repo; cd /tmp/git-repo ; \
-    git clone https://github.com/surak/Lmod.git ; \
+    git clone https://github.com/TACC/Lmod.git ; \
     cd Lmod ; \
     git fetch --tags; \
     git checkout tags/8.7.34 ; \ 


### PR DESCRIPTION
I'm trying to follow along here to make a .deb package, and I'm not sure why I should be generating my package based on anything but the official repo.