### PR TITLE
makefile warn undefined variables

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,3 +1,5 @@
+MAKEFLAGS += --warn-undefined-variables
+
 srcdir                    := @srcdir@
 prefix                    := @prefix@
 SYS_LUA_PATH              := @SYS_LUA_PATH@


### PR DESCRIPTION
I just enabled these warnings for my debian rules file while building Lmod, and I saw some warnings come out from Lmod's own makefile. It seems like a harmless addition, unless it breaks compatibility with old versions of make. I'm also not sure this is the right place to put it.