### PR TITLE
Add check before setting BASH_ENV cshrc.in

### DIFF
--- a/init/cshrc.in
+++ b/init/cshrc.in
@@ -52,7 +52,10 @@ if ( ! $?MODULEPATH_ROOT ) then
        setenv MODULEPATH `@PKGV@/libexec/addto MODULEPATH $LMOD_SITE_MODULEPATH`
     endif
        
-    setenv BASH_ENV      "@PKGV@/init/bash"
+    # Don't reset BASH_ENV if set by USER
+    if  ( ! $?BASH_ENV ) then
+       setenv BASH_ENV      "@PKGV@/init/bash"
+    endif
 
     #
     # If MANPATH is empty, Lmod is adding a trailing ":" so that


### PR DESCRIPTION
At LANL we've patched this for some time apparently. If BASH_ENV is set in `init/cshrc` then csh users won't be able to run bash scripts, which our users need to be able to do. 