### PR TITLE
update docs, allow comments in admin file with leading whitespace

### DIFF
--- a/docs/source/140_deprecating_modules.rst
+++ b/docs/source/140_deprecating_modules.rst
@@ -15,9 +15,13 @@ For example::
 
     $ module load abc/1.2.3
 
+    -----------------------------------------------------------------
+    There are messages associated with the following module(s) :
+    -----------------------------------------------------------------
     abc/1.2.3:
         This module is deprecated and will be removed from the system
         on June 19.   Please load abc/2.3.4 instead.
+    -----------------------------------------------------------------
 
 
 Note that this message is just text and in no way controls user access
@@ -64,6 +68,8 @@ full path to a modulefile.  If it doesn't then it is a
 moduleName/version string. Also, you can have several
 modulefiles use the same message by separating them with *|* 
 
+You can add comments with the `#` character.
+
 You can use Lua regular expression to also match one or modules for
 both the full path to a module or the module fullname. Lua regular
 expressions are much less powerful (see
@@ -87,7 +93,7 @@ names that have a '-' in their name requires % quoting.
 The message can be as many lines as you like.  The message ends with a
 blank line.   Below is an example::
 
-
+      # removed because ...
       gcc/2.95:    This module is deprecated and will be removed from the system on Jan 1. 1999.
                    Please switch to a newer compiler.
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -388,10 +388,9 @@ function readAdmin()
 
       for v in whole:split("\n") do
          repeat
-            v = v:gsub("%s+$","") -- trim trailing spaces
-            v = v:gsub("^%s+", "") -- trim leading spaces
+            v = v:gsub("%s+$","")
 
-            if (v:sub(1,1) == "#") then
+            if (v:gsub("^%s+", ""):sub(1,1) == "#") then
                -- ignore this comment line
                break
 

--- a/src/utils.lua
+++ b/src/utils.lua
@@ -388,7 +388,8 @@ function readAdmin()
 
       for v in whole:split("\n") do
          repeat
-            v = v:gsub("%s+$","")
+            v = v:gsub("%s+$","") -- trim trailing spaces
+            v = v:gsub("^%s+", "") -- trim leading spaces
 
             if (v:sub(1,1) == "#") then
                -- ignore this comment line


### PR DESCRIPTION
I wasn't sure if I could add comments to my admin file. The source code says I can, but only if the `#` character is at the very beginning. 

https://github.com/TACC/Lmod/blob/b46bcc82b9b37700b84bb0283cec172eda01e5eb/src/utils.lua#L423-L425

Updated the docs and made it so that comments are recognized even if there is witespace before it.

tested:

```
$ env -iS /bin/bash --norc --noprofile
bash-5.0$ source ~/Lmod-build/lmod/lmod/init/profile
bash-5.0$ export LMOD_ADMIN_PATH=/home/simonleary_umass_edu/Lmod-test/adminfile
bash-5.0$ module --config 2>&1 | grep 'Admin file'
Admin file                                                    /home/simonleary_umass_edu/Lmod-test/adminfile
bash-5.0$ cat /home/simonleary_umass_edu/Lmod-test/adminfile
# comment 1
    # comment 2
lmod:
    hello, world!
bash-5.0$ ml lmod
-------------------------------------------------------------------------------------------------------------------------------------------
There are messages associated with the following module(s):
-------------------------------------------------------------------------------------------------------------------------------------------

lmod:
    hello, world!

-------------------------------------------------------------------------------------------------------------------------------------------
```