### PR TITLE
Add ability to test a shell name on `module-info shell`

### DIFF
--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -381,7 +381,15 @@ proc module-info {what {more {}}} {
 	}
     }
     "shell" {
-        return $g_shellName
+        if {$more ne {}} {
+            if {$g_shellName eq $more} {
+               return 1
+            } else {
+               return 0
+            }
+        } else {
+            return $g_shellName
+        }
     }
     "shelltype" {
         return $g_shellType


### PR DESCRIPTION
Update Tcl `module-info shell` command to be able to test a shell name argument and return if this shell name corresponds to the current shell of the user.

This change helps to get the same behavior than Environment Modules (introduced in version 4.0) and makes Lmod compatible with the Tcl modulefile produced by the Singularity HPC tool.

An issue was raised about this by a SHPC user on envmodules/modules#560