### PR TITLE
Ensure m_Module_Msgs_close has newlines

### DIFF
--- a/messageDir/en.lua
+++ b/messageDir/en.lua
@@ -258,7 +258,7 @@ To search the contents of modules for matching words execute:
 
   $   module keyword %{s}
 ]==], --
-     m_Module_Msgs_close   = "%{border}",
+     m_Module_Msgs_close   = "%{border}\n\n",
      m_Other_matches       = "\n     Other possible modules matches:\n        %{bb}\n",
      m_Other_possible      = [==[
      Other possible modules matches:


### PR DESCRIPTION
Commit 15224be i18n-ified the closing border for `reportAdminMsgs` but it dropped the newlines. This results in the user's prompt starting in the last column next to the border

```
[root@login04 ~]# su - user
--------------------------------------------------------------------------
There are messages associated with the following module(s):
--------------------------------------------------------------------------

DefApps:
   test message

--------------------------------------------------------------------------[user@login04~]$
```