### PR TITLE
always set display mode for unuse command

### DIFF
--- a/src/cmdfuncs.lua
+++ b/src/cmdfuncs.lua
@@ -1280,12 +1280,15 @@ function UnUse(...)
    local mt     = FrameStk:singleton():mt()
    local argA   = pack(...)
    local nodups = true
+
+   local mrc    = MRC:singleton();
+   mrc:set_display_mode("all")
+
    for i = 1, argA.n do
       local v = argA[i]
       MCP:remove_path{ModulePath,  v, delim=":", nodups = true, force = true}
    end
    if (mt:changeMPATH()) then
-      local mrc = MRC:singleton(); mrc:set_display_mode("all")
       mt:reset_MPATH_change_flag()
       hub.reloadAll()
    end


### PR DESCRIPTION
Possible fix for #753 

I haven't been able to confirm this actually fixes the problem I reported via #753, but it sort of makes sense to me...

I can't reproduce the crash on `module unuse` locally (on my MBP, macOS 14.6.1, Lua 5.4.7) very easily with Lmod 8.7.57, I only see it on our HPC system (RHEL9.4, Lua 5.4.4).