### PR TITLE
allow unset PATH

### DIFF
--- a/tools/fileOps.lua
+++ b/tools/fileOps.lua
@@ -72,7 +72,7 @@ function findInPath(exec, path)
       end
    end
 
-   path    = path or os.getenv("PATH")
+   path = path or os.getenv("PATH") or ""
    for dir in path:split(":") do
       local fullcmd = pathJoin(dir, cmd)
       if (access(fullcmd,"x")) then


### PR DESCRIPTION
```console
$ bash -c '. /usr/share/lmod/lmod/init/profile; unset PATH; module --version'
/usr/bin/lua5.3: /usr/share/lmod/lmod/libexec/../tools/fileOps.lua:76: attempt to index a nil value (local 'path')
stack traceback:
	/usr/share/lmod/lmod/libexec/../tools/fileOps.lua:76: in function 'findInPath'
	/usr/share/lmod/lmod/libexec/pager.lua:87: in function 'buildPager'
	/usr/share/lmod/lmod/libexec/pager.lua:97: in main chunk
	[C]: in function 'require'
	/usr/share/lmod/lmod/libexec/lmod:111: in main chunk
	[C]: in ?
```