### PR TITLE
Add options to analyzeLmodDB in contrib/tracking_module_usage

### DIFF
--- a/contrib/tracking_module_usage/gen_2/analyzeLmodDB
+++ b/contrib/tracking_module_usage/gen_2/analyzeLmodDB
@@ -31,6 +31,7 @@ class CmdLineOptions(object):
     """ Specify command line arguments and parse the command line"""
     parser = argparse.ArgumentParser()
     parser.add_argument("--dbname",       dest='dbname',       action="store", default = "lmodV2",  help="lmod db name")
+    parser.add_argument("--confFn",       dest='confFile',     action="store", default="",          help="lmod db configuration file")
     parser.add_argument("--syshost",      dest='syshost',      action="store", default = "%",       help="system host name")
     parser.add_argument("--start",        dest='startDate',    action="store", default = "unknown", help="start date")
     parser.add_argument("--end",          dest='endDate',      action="store", default = "unknown", help="end date")
@@ -51,8 +52,11 @@ def dbConfigFn(dbname):
 def main():
   start    = time.time()
   args     = CmdLineOptions().execute()
-  configFn = dbConfigFn(args.dbname)
-  lmod     = LMODdb(configFn)
+  if os.path.isfile(args.confFile):
+      lmod = LMODdb(args.confFile)
+  else:
+      configFn = dbConfigFn(args.dbname)
+      lmod     = LMODdb(configFn)
   cmdFnd   = False
 
   if (args.cmdA[0] == "counts"):

--- a/contrib/tracking_module_usage/gen_2/analyzeLmodDB
+++ b/contrib/tracking_module_usage/gen_2/analyzeLmodDB
@@ -30,13 +30,13 @@ class CmdLineOptions(object):
   def execute(self):
     """ Specify command line arguments and parse the command line"""
     parser = argparse.ArgumentParser()
-    parser.add_argument("--dbname",       dest='dbname',       action="store", default = "lmodV2",  help="lmod db name")
-    parser.add_argument("--confFn",       dest='confFile',     action="store", default="",          help="lmod db configuration file")
-    parser.add_argument("--syshost",      dest='syshost',      action="store", default = "%",       help="system host name")
-    parser.add_argument("--start",        dest='startDate',    action="store", default = "unknown", help="start date")
-    parser.add_argument("--end",          dest='endDate',      action="store", default = "unknown", help="end date")
-    parser.add_argument("--allmodulesFn", dest='allmodulesFn', action="store", default = None,      help="File containing all modules")
-    parser.add_argument("--sqlPattern",   dest='sqlPattern',   action="store", default = "/opt/%",  help="sql pattern for matching")
+    parser.add_argument("--dbname",       dest='dbname',       action="store",  default = "lmodV2",  help="lmod db name")
+    parser.add_argument("--confFn",       dest='confFile',     action="store",  default = "",        help="lmod db configuration file")
+    parser.add_argument("--syshost",      dest='syshost',      action="append", default = [],        help="system host name")
+    parser.add_argument("--start",        dest='startDate',    action="store",  default = "unknown", help="start date")
+    parser.add_argument("--end",          dest='endDate',      action="store",  default = "unknown", help="end date")
+    parser.add_argument("--allmodulesFn", dest='allmodulesFn', action="store",  default = None,      help="File containing all modules")
+    parser.add_argument("--sqlPattern",   dest='sqlPattern',   action="append", default = [],        help="sql pattern for matching")
     parser.add_argument("cmdA",           nargs="+",           help="commands: counts, usernames, modules_used_by")
 
     args = parser.parse_args()


### PR DESCRIPTION
* Add option to specify a DB conf file (instead of DB name only). 
   Usefull to call the script from anywhere.
* Allow `--sqlPattern` and `--syshost` to be repeated. 
   Usefull to make combined filter (ie, two or more users, two or more syshost, ...)