### PR TITLE
Add module-help support for Tcl modules

### DIFF
--- a/docs/source/051_tcl_modulefiles.rst
+++ b/docs/source/051_tcl_modulefiles.rst
@@ -104,7 +104,11 @@ standard TCL language.
 
    **unuse** *path* :
       remove *path* to MODULEPATH
-   
+
+**module-help** *string* :
+    What is printed out when the help command is called. Note that
+    the *help string* can be multi-lined.
+
 **module-info** *string* :
    This command returns different things depending what *string* is:
 

--- a/rt/tclmodules/err.txt
+++ b/rt/tclmodules/err.txt
@@ -2,7 +2,7 @@
 step 1
 lua ProjectDIR/src/lmod.in.lua shell --regression_testing --version
 ===========================
-Modules based on Lua: Version 8.7.59 2025-03-06 13:51 -07:00
+Modules based on Lua: Version 8.7.65 2025-08-05 10:24 -06:00
     by Robert McLay mclay@tacc.utexas.edu
 ===========================
 step 2
@@ -33,8 +33,9 @@ step 6
 lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
 ===========================
 ProjectDIR/rt/tclmodules/mf
-   a/1.0                      getenv/1.0    hide/2.0       (D)    showMe/1.0
-   earlyLateOutput/2.0 (L)    hide/1.0      outputMode/1.0
+   a/1.0                      help/1.0        hide/2.0       (D)
+   earlyLateOutput/2.0 (L)    help/2.0 (D)    outputMode/1.0
+   getenv/1.0                 hide/1.0        showMe/1.0
   Where:
    D:  Default Module
    L:  Module is loaded
@@ -56,6 +57,7 @@ The following is a list of the modules and extensions currently available:
   a: a/1.0
   earlyLateOutput: earlyLateOutput/2.0
   getenv: getenv/1.0
+  help: help/1.0, help/2.0
   hide: hide/1.0, hide/2.0
   outputMode: outputMode/1.0
   showMe: showMe/1.0
@@ -69,3 +71,23 @@ must specify the version if there is more than one version:
 step 9
 cat myMode.log
 ===========================
+===========================
+step 10
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing load help/1.0
+===========================
+===========================
+step 11
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help help/1.0
+===========================
+Module Specific Help for "help/1.0"
+first help line
+with newline
+second help line
+===========================
+step 12
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help help/2.0
+===========================
+Module Specific Help for "help/2.0"
+first help line
+with newline
+second help line

--- a/rt/tclmodules/mf/help/1.0
+++ b/rt/tclmodules/mf/help/1.0
@@ -1,0 +1,4 @@
+#%Module
+module-help {first help line
+with newline}
+module-help {second help line}

--- a/rt/tclmodules/mf/help/2.0
+++ b/rt/tclmodules/mf/help/2.0
@@ -1,0 +1,6 @@
+#%Module
+proc ModulesHelp {} {
+    puts stderr {second help line}
+}
+module-help {first help line
+with newline}

--- a/rt/tclmodules/out.txt
+++ b/rt/tclmodules/out.txt
@@ -80,3 +80,31 @@ step 9
 cat myMode.log
 ===========================
 myMode: spider
+===========================
+step 10
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing load help/1.0
+===========================
+LOADEDMODULES=earlyLateOutput/2.0:getenv/1.0:help/1.0;
+export LOADEDMODULES;
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_LMFILES_=ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0:ProjectDIR/rt/tclmodules/mf/getenv/1.0:ProjectDIR/rt/tclmodules/mf/help/1.0;
+export _LMFILES_;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;
+===========================
+step 11
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help help/1.0
+===========================
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;
+===========================
+step 12
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help help/2.0
+===========================
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;

--- a/rt/tclmodules/tclmodules.tdesc
+++ b/rt/tclmodules/tclmodules.tdesc
@@ -33,6 +33,9 @@ testdescript = {
      runLmod load getenv                       # 7
      runLmod spider                            # 8
      runBase cat myMode.log                    # 9
+     runLmod load help/1.0                     # 10
+     runLmod help help/1.0                     # 11
+     runLmod help help/2.0                     # 12
 
      HOME=$ORIG_HOME
      cat _stdout.[0-9][0-9][0-9] > _stdout.orig

--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -410,6 +410,12 @@ proc getModCmdOpts { &answerA &extraArgs args  } {
    set  resultA(mode) $modeStr
 }
 
+proc module-help {args} {
+    global g_outputA
+    set msg [join $args]
+    lappend g_outputA  "help(\[===\[$msg\]===\])\n"
+}
+
 proc module-info {what {more {}}} {
     global g_fullName g_usrName g_shellName g_shellType
     set mode [currentMode]
@@ -1077,6 +1083,7 @@ proc execute-modulefile {modfile } {
     interp alias $child is-loaded      	 {} is-loaded
     interp alias $child is-avail      	 {} is-avail
     interp alias $child module         	 {} module
+    interp alias $child module-help    	 {} module-help
     interp alias $child module-info    	 {} module-info
     interp alias $child module-whatis  	 {} module-whatis
     interp alias $child myPuts         	 {} myPuts


### PR DESCRIPTION
The "module-help" modulefile command has been introduced in Environment Modules 5.6 to provide a way to define help messages simpler than the traditional ModulesHelp procedure, like achieved on Lua modulefiles with the "help()" function.

This commit adds "module-help" support for Tcl modulefiles and make it map to the "help()" Lua function when translated by tcl2lua.tcl.