### PR TITLE
doc: fix doc of "extensions" Tcl modulefile command

### DIFF
--- a/docs/source/051_tcl_modulefiles.rst
+++ b/docs/source/051_tcl_modulefiles.rst
@@ -56,9 +56,8 @@ standard TCL language.
    Exits the module.  No changes in the environment occur if this
    command is found.
 
-**extensions** "numpy/2.1 scipy/3.2" :
-   This module provides the following extensions. Place the list of
-   extensions as a single string.
+**extensions** A B :
+   This module provides the following extensions.
 
 **family NAME** :
    A user can only have one family "name" loaded at a time. For


### PR DESCRIPTION
"extensions" Tcl modulefile command accepts a list of argument. Fix documentation that stated the command accepts a single string.