### PR TITLE
Introduce EasyBuild test in GitHub actions

### DIFF
--- a/.github/workflows/easybuild.yml
+++ b/.github/workflows/easybuild.yml
@@ -1,0 +1,55 @@
+name: run EasyBuild framework tests
+on: [push, pull_request]
+
+jobs:
+  framework:
+    strategy:
+      fail-fast: false
+      matrix:
+        module_syntax: [Lua, Tcl]
+    runs-on: ubuntu-24.04
+    env:
+      EASYBUILD_MODULES_TOOL: Lmod
+      EASYBUILD_MODULE_SYNTAX: ${{ matrix.module_syntax }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - name: Install system packages
+        run: |
+          sudo apt-get -y update
+          # package required to build and install Lmod
+          sudo apt-get install -y gcc tcl tcl-dev lua5.3 liblua5.3-dev lua-filesystem lua-json lua-posix lua-term
+          # EasyBuild framework test requirement
+          sudo apt-get install -y python3 python3-pycodestyle python3-pygraphviz python3-autopep8
+      - name: Build and Install Lmod
+        run: |
+          ./configure
+          sudo make install
+      - name: Fetch EasyBuild framework
+        run: |
+          # need to setup repository in HOME for test_run_shell_cmd_fail to succeed
+          cd $HOME
+          git clone https://github.com/easybuilders/easybuild-framework.git
+          cd easybuild-framework
+          latest_tag=$(git describe --tags "$(git rev-list --tags --max-count=1)")
+          git switch --detach $latest_tag
+      - name: Test EasyBuild framework suite with Lmod
+        run: |
+          cd ${HOME}/easybuild-framework
+          source /usr/local/lmod/lmod/init/bash
+          export TEST_EASYBUILD_MODULES_TOOL=${EASYBUILD_MODULES_TOOL}
+          export TEST_EASYBUILD_MODULE_SYNTAX=${EASYBUILD_MODULE_SYNTAX}
+          export PYTHONPATH=$(pwd):$PYTHONPATH
+          export PATH=$(pwd):$PATH
+          # fake this is a pull request build to skip test_push_branch_to_github
+          export GITHUB_EVENT_NAME=pull_request
+          # record output in file to check test suite result
+          python -m test.framework.suite 2>&1 | tee test_framework_suite.log
+          tail -n 1 test_framework_suite.log | grep --quiet '^OK$'
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: easybuild-${{ matrix.module_syntax }}-tests-logs-${{ github.job }}
+          path: /tmp/eb-*/eb-*/easybuild-tests-*.log
+          retention-days: 5


### PR DESCRIPTION
Add CI test to check Lmod changes against EasyBuild framework non-regression test suite.

Such test will help to catch issue introduced on EasyBuild, like #792.