### PR TITLE
Add "report" support for Tcl modules

### DIFF
--- a/docs/source/051_tcl_modulefiles.rst
+++ b/docs/source/051_tcl_modulefiles.rst
@@ -157,6 +157,9 @@ standard TCL language.
 **remove-property NAME** *value* :
    See :ref:`lmodrc-label` for how to use this command.
 
+**report** *string* :
+  Prints a message to the user.
+
 **reportError** *string* :
   Report an error and abort processing of the modulefile.
 

--- a/rt/tclmodules/err.txt
+++ b/rt/tclmodules/err.txt
@@ -33,9 +33,9 @@ step 6
 lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
 ===========================
 ProjectDIR/rt/tclmodules/mf
-   a/1.0                      help/1.0        hide/2.0       (D)
+   a/1.0                      help/1.0        hide/2.0       (D)    showMe/1.0
    earlyLateOutput/2.0 (L)    help/2.0 (D)    outputMode/1.0
-   getenv/1.0                 hide/1.0        showMe/1.0
+   getenv/1.0                 hide/1.0        report/1.0
   Where:
    D:  Default Module
    L:  Module is loaded
@@ -60,6 +60,7 @@ The following is a list of the modules and extensions currently available:
   help: help/1.0, help/2.0
   hide: hide/1.0, hide/2.0
   outputMode: outputMode/1.0
+  report: report/1.0
   showMe: showMe/1.0
 To learn more about a package execute:
    $ module spider Foo
@@ -91,3 +92,24 @@ Module Specific Help for "help/2.0"
 first help line
 with newline
 second help line
+===========================
+step 13
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing load report/1.0
+===========================
+line of text to report
+===========================
+step 14
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing show report/1.0
+===========================
+   ProjectDIR/rt/tclmodules/mf/report/1.0:
+LmodMessage("line of text to report")
+===========================
+step 15
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help report/1.0
+===========================
+Module Specific Help for "report/1.0"
+===========================
+step 16
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing unload report/1.0
+===========================
+line of text to report

--- a/rt/tclmodules/mf/report/1.0
+++ b/rt/tclmodules/mf/report/1.0
@@ -1,0 +1,2 @@
+#%Module
+report {line of text to report}

--- a/rt/tclmodules/out.txt
+++ b/rt/tclmodules/out.txt
@@ -108,3 +108,43 @@ MODULEPATH=ProjectDIR/rt/tclmodules/mf;
 export MODULEPATH;
 _ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
 export _ModuleTable_;
+===========================
+step 13
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing load report/1.0
+===========================
+LOADEDMODULES=earlyLateOutput/2.0:getenv/1.0:help/1.0:report/1.0;
+export LOADEDMODULES;
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_LMFILES_=ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0:ProjectDIR/rt/tclmodules/mf/getenv/1.0:ProjectDIR/rt/tclmodules/mf/help/1.0:ProjectDIR/rt/tclmodules/mf/report/1.0;
+export _LMFILES_;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},report={fn="ProjectDIR/rt/tclmodules/mf/report/1.0",fullName="report/1.0",loadOrder=4,propT={},stackDepth=0,status="active",userName="report/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;
+===========================
+step 14
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing show report/1.0
+===========================
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},report={fn="ProjectDIR/rt/tclmodules/mf/report/1.0",fullName="report/1.0",loadOrder=4,propT={},stackDepth=0,status="active",userName="report/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;
+===========================
+step 15
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing help report/1.0
+===========================
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},report={fn="ProjectDIR/rt/tclmodules/mf/report/1.0",fullName="report/1.0",loadOrder=4,propT={},stackDepth=0,status="active",userName="report/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;
+===========================
+step 16
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing unload report/1.0
+===========================
+LOADEDMODULES=earlyLateOutput/2.0:getenv/1.0:help/1.0;
+export LOADEDMODULES;
+MODULEPATH=ProjectDIR/rt/tclmodules/mf;
+export MODULEPATH;
+_LMFILES_=ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0:ProjectDIR/rt/tclmodules/mf/getenv/1.0:ProjectDIR/rt/tclmodules/mf/help/1.0;
+export _LMFILES_;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={earlyLateOutput={fn="ProjectDIR/rt/tclmodules/mf/earlyLateOutput/2.0",fullName="earlyLateOutput/2.0",loadOrder=1,propT={},stackDepth=0,status="active",userName="earlyLateOutput",wV="000000002.*zfinal",},getenv={fn="ProjectDIR/rt/tclmodules/mf/getenv/1.0",fullName="getenv/1.0",loadOrder=2,propT={},stackDepth=0,status="active",userName="getenv",wV="000000001.*zfinal",},help={fn="ProjectDIR/rt/tclmodules/mf/help/1.0",fullName="help/1.0",loadOrder=3,propT={},stackDepth=0,status="active",userName="help/1.0",wV="000000001.*zfinal",},},mpathA={"ProjectDIR/rt/tclmodules/mf",},systemBaseMPATH="ProjectDIR/rt/tclmodules/mf",}';
+export _ModuleTable_;

--- a/rt/tclmodules/tclmodules.tdesc
+++ b/rt/tclmodules/tclmodules.tdesc
@@ -36,6 +36,10 @@ testdescript = {
      runLmod load help/1.0                     # 10
      runLmod help help/1.0                     # 11
      runLmod help help/2.0                     # 12
+     runLmod load report/1.0                   # 13
+     runLmod show report/1.0                   # 14
+     runLmod help report/1.0                   # 15
+     runLmod unload report/1.0                 # 16
 
      HOME=$ORIG_HOME
      cat _stdout.[0-9][0-9][0-9] > _stdout.orig

--- a/src/tcl2lua.tcl
+++ b/src/tcl2lua.tcl
@@ -1049,6 +1049,11 @@ proc module { command args } {
     }
 }
 
+proc report {message} {
+    global g_outputA
+    lappend g_outputA "LmodMessage(\[===\[$message\]===\])\n"
+}
+
 proc reportError {message} {
     global g_outputA
     global ModulesCurrentModulefile g_fullName
@@ -1095,6 +1100,7 @@ proc execute-modulefile {modfile } {
     interp alias $child puts           	 {} myPuts
     interp alias $child remove-path    	 {} remove-path
     interp alias $child remove-property  {} remove-property
+    interp alias $child report           {} report
     interp alias $child reportError      {} reportError
     interp alias $child require-fullname {} require-fullname
     interp alias $child set-alias        {} set-alias


### PR DESCRIPTION
The "report" modulefile command is available in Environment Modules to provide a way for modulefile developer to print text to user, like achieved on Lua modulefiles with the "LmodMessage()" function.

This commit adds "report" support for Tcl modulefiles and make it map to the "LmodMessage()" Lua function when translated by tcl2lua.tcl.