### PR TITLE
Fix exporting of `module` function in Bash

### DIFF
--- a/init/bash.in
+++ b/init/bash.in
@@ -157,6 +157,7 @@ ml()
 }
 
 if [ -n "${BASH_VERSION:-}" -a "@export_module@" != no ]; then
+  export -f __lmod_internal_module_cmd
   export -f module
   export -f ml
 fi


### PR DESCRIPTION
15b5772889b8f2cba005a3df990b5b8531329b80 introduced a helper method `__lmod_internal_module_cmd`, however this is not exported. Hence on subshells `module` and `ml` is defined but call the non-existing `__lmod_internal_module_cmd` function and fail.