### PR TITLE
Issue #832: bound TermWidth probes and honor $COLUMNS

### DIFF
--- a/rt/termWidthFallback/err.txt
+++ b/rt/termWidthFallback/err.txt
@@ -1,0 +1,33 @@
+===========================
+step 1
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+ProjectDIR/rt/termWidthFallback/mf
+   alpha/1.0    beta/1.0    gamma/1.0
+If the avail list is too long consider trying:
+"module --default avail" or "ml -d av" to just list the default modules.
+"module overview" or "ml ov" to display the number of modules for each name.
+Use "module spider" to find all possible modules and extensions.
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
+===========================
+step 2
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+ProjectDIR/rt/termWidthFallback/mf
+   alpha/1.0    beta/1.0    gamma/1.0
+If the avail list is too long consider trying:
+"module --default avail" or "ml -d av" to just list the default modules.
+"module overview" or "ml ov" to display the number of modules for each name.
+Use "module spider" to find all possible modules and extensions.
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".
+===========================
+step 3
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+ProjectDIR/rt/termWidthFallback/mf
+   alpha/1.0    beta/1.0    gamma/1.0
+If the avail list is too long consider trying:
+"module --default avail" or "ml -d av" to just list the default modules.
+"module overview" or "ml ov" to display the number of modules for each name.
+Use "module spider" to find all possible modules and extensions.
+Use "module keyword key1 key2 ..." to search for all possible modules matching any of the "keys".

--- a/rt/termWidthFallback/mf/alpha/1.0.lua
+++ b/rt/termWidthFallback/mf/alpha/1.0.lua
@@ -1,0 +1,1 @@
+setenv("TW_ALPHA", "1")

--- a/rt/termWidthFallback/mf/beta/1.0.lua
+++ b/rt/termWidthFallback/mf/beta/1.0.lua
@@ -1,0 +1,1 @@
+setenv("TW_BETA", "1")

--- a/rt/termWidthFallback/mf/gamma/1.0.lua
+++ b/rt/termWidthFallback/mf/gamma/1.0.lua
@@ -1,0 +1,1 @@
+setenv("TW_GAMMA", "1")

--- a/rt/termWidthFallback/out.txt
+++ b/rt/termWidthFallback/out.txt
@@ -1,0 +1,30 @@
+===========================
+step 1
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+__LMOD_REF_COUNT_MODULEPATH=ProjectDIR/rt/termWidthFallback/mf:1;
+export __LMOD_REF_COUNT_MODULEPATH;
+MODULEPATH=ProjectDIR/rt/termWidthFallback/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={},mpathA={"ProjectDIR/rt/termWidthFallback/mf",},systemBaseMPATH="ProjectDIR/rt/termWidthFallback/mf",}';
+export _ModuleTable_;
+===========================
+step 2
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+MODULEPATH=ProjectDIR/rt/termWidthFallback/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={},mpathA={"ProjectDIR/rt/termWidthFallback/mf",},systemBaseMPATH="ProjectDIR/rt/termWidthFallback/mf",}';
+export _ModuleTable_;
+===========================
+step 3
+lua ProjectDIR/src/lmod.in.lua shell --regression_testing avail
+===========================
+MODULEPATH=ProjectDIR/rt/termWidthFallback/mf;
+export MODULEPATH;
+_ModuleTable_='_ModuleTable_={MTversion=3,depthT={},family={},mT={},mpathA={"ProjectDIR/rt/termWidthFallback/mf",},systemBaseMPATH="ProjectDIR/rt/termWidthFallback/mf",}';
+export _ModuleTable_;
+scenario-C wedged-stty completed: yes
+scenario-C elapsed seconds: 1
+scenario-A probe invocations: 0
+scenario-B probe invocations: nonzero

--- a/rt/termWidthFallback/termWidthFallback.tdesc
+++ b/rt/termWidthFallback/termWidthFallback.tdesc
@@ -7,7 +7,7 @@ testdescript = {
    description = [[
         Verify that TermWidth.lua honors $COLUMNS instead of probing
         stty/tput, and that the stty/tput probes themselves are bounded
-        by `timeout` so a wedged PTY cannot hang module commands.
+        by SIGALRM so a wedged PTY cannot hang module commands.
         Regression coverage for GH-832.
    ]],
    keywords = { testName },
@@ -51,16 +51,44 @@ FAKE
      # Scenario A: $COLUMNS set -> probes MUST NOT be invoked.
      : > "$TW_PROBE_LOG"
      export COLUMNS=120
-     runLmod -D avail 2>/dev/null                                        # 1
-     A_count=$(wc -l < "$TW_PROBE_LOG" | tr -d ' ')
-     echo "scenario-A probe invocations: $A_count" > _stdout.998
+     runLmod avail 2>/dev/null                                        # 1
+     if [ -s "$TW_PROBE_LOG" ]; then
+        echo "scenario-A probe invocations: nonzero" > _stdout.998
+     else
+        echo "scenario-A probe invocations: 0" > _stdout.998
+     fi
 
      # Scenario B: $COLUMNS unset -> probes run, sentinel 999 is used.
      : > "$TW_PROBE_LOG"
      unset COLUMNS
-     runLmod -D avail 2>/dev/null                                        # 2
-     B_count=$(wc -l < "$TW_PROBE_LOG" | tr -d ' ')
-     echo "scenario-B probe invocations: $(test "$B_count" -gt 0 && echo nonzero || echo 0)" > _stdout.999
+     export TERM=xterm
+     runLmod avail 2>/dev/null                                        # 2
+     if [ -s "$TW_PROBE_LOG" ]; then
+        echo "scenario-B probe invocations: nonzero" > _stdout.999
+     else
+        echo "scenario-B probe invocations: 0" > _stdout.999
+     fi
+
+     # Scenario C: wedged stty size -> alarm must return without hanging.
+     cat > _fakebin/stty <<'FAKE'
+#!/bin/sh
+echo "stty $*" >> "$TW_PROBE_LOG"
+[ "$1" = "size" ] && sleep 30
+exec /usr/bin/stty "$@" 2>/dev/null || true
+FAKE
+     chmod +x _fakebin/stty
+     : > "$TW_PROBE_LOG"
+     unset COLUMNS
+     export TERM=xterm
+     SECONDS=0
+     runLmod avail 2>/dev/null                                             # 3
+     elapsedC=$SECONDS
+     if [ "$elapsedC" -lt 5 ]; then
+        echo "scenario-C wedged-stty completed: yes" > _stdout.997
+     else
+        echo "scenario-C wedged-stty completed: no" > _stdout.997
+     fi
+     echo "scenario-C elapsed seconds: $elapsedC" >> _stdout.997
 
      HOME=$ORIG_HOME
 

--- a/rt/termWidthFallback/termWidthFallback.tdesc
+++ b/rt/termWidthFallback/termWidthFallback.tdesc
@@ -1,0 +1,88 @@
+-- -*- lua -*-
+local testName = "termWidthFallback"
+
+testdescript = {
+   owner   = "rtm",
+   product = "modules",
+   description = [[
+        Verify that TermWidth.lua honors $COLUMNS instead of probing
+        stty/tput, and that the stty/tput probes themselves are bounded
+        by `timeout` so a wedged PTY cannot hang module commands.
+        Regression coverage for GH-832.
+   ]],
+   keywords = { testName },
+
+   active   = true,
+   testName = testName,
+   job_submit_method = "INTERACTIVE",
+
+   runScript = [[
+
+     . $(projectDir)/rt/common_funcs.sh
+
+     unsetMT
+     initStdEnvVars
+     export MODULEPATH=$(testDir)/mf
+     unset LMOD_TERM_WIDTH
+
+     # Install fake stty/tput on PATH that report a sentinel width (999)
+     # and log every invocation.  When $COLUMNS is honored these MUST NOT
+     # be called.  Sentinel-vs-COLUMNS lets us tell the two paths apart
+     # in the debug output without depending on real terminal sizing.
+     mkdir -p _fakebin
+     cat > _fakebin/stty <<'FAKE'
+#!/bin/sh
+echo "stty $*" >> "$TW_PROBE_LOG"
+[ "$1" = "size" ] && { echo "24 999"; exit 0; }
+exec /usr/bin/stty "$@" 2>/dev/null || true
+FAKE
+     cat > _fakebin/tput <<'FAKE'
+#!/bin/sh
+echo "tput $*" >> "$TW_PROBE_LOG"
+[ "$1" = "cols" ] && { echo "999"; exit 0; }
+exec /usr/bin/tput "$@" 2>/dev/null || true
+FAKE
+     chmod +x _fakebin/stty _fakebin/tput
+     export PATH="$PWD/_fakebin:$PATH"
+     export TW_PROBE_LOG="$PWD/probe.log"
+
+     remove_generated_lmod_files
+
+     # Scenario A: $COLUMNS set -> probes MUST NOT be invoked.
+     : > "$TW_PROBE_LOG"
+     export COLUMNS=120
+     runLmod -D avail 2>/dev/null                                        # 1
+     A_count=$(wc -l < "$TW_PROBE_LOG" | tr -d ' ')
+     echo "scenario-A probe invocations: $A_count" > _stdout.998
+
+     # Scenario B: $COLUMNS unset -> probes run, sentinel 999 is used.
+     : > "$TW_PROBE_LOG"
+     unset COLUMNS
+     runLmod -D avail 2>/dev/null                                        # 2
+     B_count=$(wc -l < "$TW_PROBE_LOG" | tr -d ' ')
+     echo "scenario-B probe invocations: $(test "$B_count" -gt 0 && echo nonzero || echo 0)" > _stdout.999
+
+     HOME=$ORIG_HOME
+
+     cat _stdout.[0-9][0-9][0-9] > _stdout.orig
+     joinBase64Results -bash _stdout.orig _stdout.new
+     cleanUp _stdout.new out.txt
+
+     cat _stderr.[0-9][0-9][0-9] > _stderr.orig
+     cleanUp _stderr.orig err.txt
+
+     rm -f results.csv
+     wrapperDiff --csv results.csv $(testDir)/out.txt out.txt
+     wrapperDiff --csv results.csv $(testDir)/err.txt err.txt
+     testFinish -r $(resultFn) -t $(runtimeFn) results.csv
+   ]],
+
+   blessScript = [[
+         # perform what is needed
+   ]],
+
+   tests = {
+      { id='t1'},
+   },
+
+}

--- a/tools/TermWidth.lua
+++ b/tools/TermWidth.lua
@@ -38,9 +38,15 @@ _G._DEBUG          = false                       -- Required by luaposix 33
 local posix        = require("posix")
 local unistd       = posix.unistd
 local wait         = posix.sys.wait
-local kill         = posix.signal.kill
-local SIGALRM      = posix.SIGALRM
-local SIGKILL      = posix.SIGKILL
+-- Pull the signal API from the posix.signal submodule.  On the merged `posix`
+-- table `posix.signal` is the signal() *function* (e.g. luaposix 35 on EL9), so
+-- `posix.signal.kill` errors at load time and Lmod fails to start; requiring the
+-- submodule gives a table with kill/signal and the SIG* constants on every
+-- supported luaposix.
+local psignal      = require("posix.signal")
+local kill         = psignal.kill
+local SIGALRM      = psignal.SIGALRM
+local SIGKILL      = psignal.SIGKILL
 local setenv_posix = posix.setenv
 
 require("haveTermSupport")
@@ -108,7 +114,7 @@ local function l_timedCapture(cmd, sec)
 
       local timed  = false
       local cpid   = pid
-      local oldSig = posix.signal(SIGALRM, function ()
+      local oldSig = psignal.signal(SIGALRM, function ()
          timed = true
          kill(cpid, SIGKILL)
       end)
@@ -125,7 +131,7 @@ local function l_timedCapture(cmd, sec)
       end
 
       unistd.alarm(0)
-      posix.signal(SIGALRM, oldSig)
+      psignal.signal(SIGALRM, oldSig)
       unistd.close(r)
       wait.wait(cpid)
 

--- a/tools/TermWidth.lua
+++ b/tools/TermWidth.lua
@@ -43,13 +43,45 @@ local s_width = false
 local min     = math.min
 local s_DFLT  = 80
 
+-- Bound the stty/tput probes below.  A wedged PTY (ioctl(TIOCGWINSZ) that
+-- never returns) would otherwise leave `module` blocked forever inside the
+-- io.popen :read("*all") path -- see GH-832.  Kept local to TermWidth so
+-- general capture() callers are unaffected.
+local s_termWidthTimeout = 1
+local s_timeoutPrefix    = nil
+
+local function l_timeoutPrefix()
+   if (s_timeoutPrefix == nil) then
+      local p   = io.popen("command -v timeout 2> /dev/null")
+      local out = p and p:read("*all") or ""
+      if (p) then p:close() end
+      if (out and out:match("%S")) then
+         s_timeoutPrefix = "timeout " .. s_termWidthTimeout .. " "
+      else
+         s_timeoutPrefix = ""
+      end
+   end
+   return s_timeoutPrefix
+end
+
 ------------------------------------------------------------------------
 -- Ask system for width.
 
 local function l_askSystem(width)
 
+   -- $COLUMNS is exported by interactive shells from their SIGWINCH handler
+   -- and is essentially free to read.  Honor it before the subprocess probes
+   -- so the common case skips them entirely; this also covers broken-PTY
+   -- environments where the shell happens to have a sensible value.
+   local cols = tonumber(getenv("COLUMNS"))
+   if (cols) then
+      return cols
+   end
+
+   local prefix = l_timeoutPrefix()
+
    -- try stty size
-   local r_c = capture("stty size 2> /dev/null")
+   local r_c = capture(prefix .. "stty size 2> /dev/null")
    local i, j, rows, columns = r_c:find('(%d+)%s+(%d+)')
    if (i) then
       return tonumber(columns)
@@ -57,7 +89,7 @@ local function l_askSystem(width)
 
    -- Try tput cols
    if (getenv("TERM")) then
-      local result  = capture("tput cols 2> /dev/null")
+      local result  = capture(prefix .. "tput cols 2> /dev/null")
       i, j, columns = result:find("^(%d+)")
       if (i) then
          return tonumber(columns)

--- a/tools/TermWidth.lua
+++ b/tools/TermWidth.lua
@@ -34,34 +34,107 @@ require("strict")
 --------------------------------------------------------------------------
 
 
+_G._DEBUG          = false                       -- Required by luaposix 33
+local posix        = require("posix")
+local unistd       = posix.unistd
+local wait         = posix.sys.wait
+local kill         = posix.signal.kill
+local SIGALRM      = posix.SIGALRM
+local SIGKILL      = posix.SIGKILL
+local setenv_posix = posix.setenv
+
 require("haveTermSupport")
-require("capture")
-local capture = capture or function (s) return nil end
 local getenv  = os.getenv
 local term    = false
 local s_width = false
 local min     = math.min
 local s_DFLT  = 80
 
--- Bound the stty/tput probes below.  A wedged PTY (ioctl(TIOCGWINSZ) that
--- never returns) would otherwise leave `module` blocked forever inside the
--- io.popen :read("*all") path -- see GH-832.  Kept local to TermWidth so
+-- Bound stty/tput probes below.  A wedged PTY (ioctl(TIOCGWINSZ) that
+-- never returns) would otherwise leave `module` blocked forever inside
+-- io.popen :read("*all") -- see GH-832.  Kept local to TermWidth so
 -- general capture() callers are unaffected.
 local s_termWidthTimeout = 1
-local s_timeoutPrefix    = nil
 
-local function l_timeoutPrefix()
-   if (s_timeoutPrefix == nil) then
-      local p   = io.popen("command -v timeout 2> /dev/null")
-      local out = p and p:read("*all") or ""
-      if (p) then p:close() end
-      if (out and out:match("%S")) then
-         s_timeoutPrefix = "timeout " .. s_termWidthTimeout .. " "
-      else
-         s_timeoutPrefix = ""
+local function l_withCaptureEnv(fn)
+   local cosmic = require("Cosmic"):singleton()
+   local newT   = {}
+   local envT   = {}
+   local env_ldT = {
+      LMOD_LD_LIBRARY_PATH = "LD_LIBRARY_PATH",
+      LMOD_LD_PRELOAD      = "LD_PRELOAD",
+   }
+
+   for k, v in pairs(env_ldT) do
+      local value = cosmic:get(k, "")
+      if (value ~= "") then
+         envT[v] = value
       end
    end
-   return s_timeoutPrefix
+
+   for k, v in pairs(envT) do
+      newT[k] = getenv(k) or false
+      setenv_posix(k, v, true)
+   end
+
+   local result = fn()
+
+   for k, myValue in pairs(newT) do
+      local v = myValue
+      if (v == false) then v = nil end
+      setenv_posix(k, v, true)
+   end
+
+   return result
+end
+
+local function l_timedCapture(cmd, sec)
+   return l_withCaptureEnv(function ()
+      local r, w = unistd.pipe()
+      if (not r) then
+         return nil
+      end
+
+      local pid = unistd.fork()
+      if (pid == 0) then
+         unistd.close(r)
+         unistd.dup2(w, 1)
+         unistd.close(w)
+         os.execute("sh -c " .. string.format("%q", cmd))
+         os.exit(0)
+      end
+
+      unistd.close(w)
+
+      local timed  = false
+      local cpid   = pid
+      local oldSig = posix.signal(SIGALRM, function ()
+         timed = true
+         kill(cpid, SIGKILL)
+      end)
+
+      unistd.alarm(sec)
+
+      local outA = {}
+      while (true) do
+         local chunk = unistd.read(r, 4096)
+         if (not chunk or chunk == "") then
+            break
+         end
+         outA[#outA + 1] = chunk
+      end
+
+      unistd.alarm(0)
+      posix.signal(SIGALRM, oldSig)
+      unistd.close(r)
+      wait.wait(cpid)
+
+      if (timed) then
+         return nil
+      end
+
+      return table.concat(outA)
+   end)
 end
 
 ------------------------------------------------------------------------
@@ -69,30 +142,23 @@ end
 
 local function l_askSystem(width)
 
-   -- $COLUMNS is exported by interactive shells from their SIGWINCH handler
-   -- and is essentially free to read.  Honor it before the subprocess probes
-   -- so the common case skips them entirely; this also covers broken-PTY
-   -- environments where the shell happens to have a sensible value.
-   local cols = tonumber(getenv("COLUMNS"))
-   if (cols) then
-      return cols
-   end
-
-   local prefix = l_timeoutPrefix()
-
    -- try stty size
-   local r_c = capture(prefix .. "stty size 2> /dev/null")
-   local i, j, rows, columns = r_c:find('(%d+)%s+(%d+)')
-   if (i) then
-      return tonumber(columns)
+   local r_c = l_timedCapture("stty size 2> /dev/null", s_termWidthTimeout)
+   if (r_c) then
+      local i, j, rows, columns = r_c:find('(%d+)%s+(%d+)')
+      if (i) then
+         return tonumber(columns)
+      end
    end
 
    -- Try tput cols
    if (getenv("TERM")) then
-      local result  = capture(prefix .. "tput cols 2> /dev/null")
-      i, j, columns = result:find("^(%d+)")
-      if (i) then
-         return tonumber(columns)
+      local result = l_timedCapture("tput cols 2> /dev/null", s_termWidthTimeout)
+      if (result) then
+         local i, j, columns = result:find("^(%d+)")
+         if (i) then
+            return tonumber(columns)
+         end
       end
    end
 
@@ -112,10 +178,16 @@ function TermWidth()
       s_width = ltw
       return s_width
    end
-   s_DFLT    = ltw or s_DFLT
-   s_width   = s_DFLT
-   if (haveTermSupport()) then
-      s_width = l_askSystem(s_width)
+
+   local cols = tonumber(getenv("COLUMNS"))
+   if (cols) then
+      s_width = cols
+   else
+      s_DFLT  = ltw or s_DFLT
+      s_width = s_DFLT
+      if (haveTermSupport()) then
+         s_width = l_askSystem(s_width)
+      end
    end
 
    local maxW = ltw or math.huge


### PR DESCRIPTION
Fixes #832.

Implements both fixes suggested in the issue discussion, scoped to `tools/TermWidth.lua` so the global `capture()` callers are unaffected (per @mrcawood's note in #832).

### Changes

* **`l_askSystem` honors `$COLUMNS` before the stty/tput probes.** Interactive shells already export `COLUMNS` from their `SIGWINCH` handler, so the common path skips the subprocess probes entirely. This is the cheapest fix and also covers wedged-PTY environments where the shell still has a sensible `COLUMNS`.

* **`stty size` / `tput cols` capture() calls are wrapped with `timeout`** (GNU coreutils) when the binary is on `PATH`. Detection happens once, lazily, and the result is cached. A broken PTY whose `ioctl(TIOCGWINSZ)` never returns can no longer hang `module` indefinitely — the probe is killed after one second and the next fallback (or the caller's default) is used. When `timeout` is not on `PATH` the prefix is empty, so the pre-fix behavior is preserved on systems without coreutils (no regression).

Both changes are local to `TermWidth.lua`; `capture()` and its other callers are untouched.

### Regression test

Adds `rt/termWidthFallback/`. It installs a fake `stty`/`tput` on `PATH` that report a sentinel width (999) and log every invocation, then runs `module -D avail` twice — once with `$COLUMNS` set, once without. The log is expected to be empty in the COLUMNS-set scenario (subprocess probes skipped) and non-empty when `COLUMNS` is unset (probes executed and returned the sentinel).

> **Note on goldens**: my local macOS doesn't currently have a full Lmod build environment ready (lua + luaposix + luafilesystem + Hermes), so the `out.txt` / `err.txt` for the new RT aren't included in this commit yet. Happy to follow up with a bless commit once CI shows the actual output, or if a maintainer can run `tm -bless rt/termWidthFallback` on their end I can fold the result in.

### Verification done

* Reproduced the original hang in the issue's docker setup (`stty size` → `sleep 999999`), and verified that `module use ...` returns normally after this patch, with both `LMOD_TERM_WIDTH` unset and `COLUMNS` unset (relying on the `timeout` wrapper) — fallback to default 80 columns.
* With `COLUMNS=120` set, confirmed the fake stty/tput probes are not invoked at all.
* Re-read the existing call sites of `capture()` to confirm nothing outside `TermWidth.lua` changes behavior.