### PR TITLE
Fix typo `LD_LIBRAfRY_PATH`

### DIFF
--- a/rt/common_funcs.sh
+++ b/rt/common_funcs.sh
@@ -202,7 +202,7 @@ runLmod ()
 runLmodProtectedVars ()
 {
    runCoreBase "$@"
-   __LMOD_PROTECTED_LD_LIBRARY_PATH=/def/abc:/qrtst/def LD_LIBRAfRY_PATH= $LUA_EXEC $projectDir/src/lmod.in.lua shell --regression_testing --protected_vars "$@" > _stdout.$NUM 2>> _stderr.$NUM
+   __LMOD_PROTECTED_LD_LIBRARY_PATH=/def/abc:/qrtst/def LD_LIBRARY_PATH= $LUA_EXEC $projectDir/src/lmod.in.lua shell --regression_testing --protected_vars "$@" > _stdout.$NUM 2>> _stderr.$NUM
    eval "`cat _stdout.$NUM`"
 }
 


### PR DESCRIPTION
This wasn't intentional, was it?