### PR TITLE
Fix error in `set -u` bash context

### DIFF
--- a/init/bash.in
+++ b/init/bash.in
@@ -86,8 +86,8 @@ __lmod_internal_module_cmd()
 {
   ############################################################
   # Run Lmod and eval results
-  eval "$( __LMOD_PROTECTED_LD_LIBRARY_PATH=$LD_LIBRARY_PATH \
-           __LMOD_PROTECTED_LD_PRELOAD=$LD_PRELOAD           \
+  eval "$( __LMOD_PROTECTED_LD_LIBRARY_PATH=${LD_LIBRARY_PATH:-} \
+           __LMOD_PROTECTED_LD_PRELOAD=${LD_PRELOAD:-}           \
            LD_LIBRARY_PATH=@sys_ld_lib_path@                 \
            LD_PRELOAD=@sys_ld_preload@                       \
            $LMOD_CMD @my_shell@ --protected_vars "$@")" && eval $(${LMOD_SETTARG_CMD:-:} -s sh)


### PR DESCRIPTION
Make reading `LD_LIBRARY_PATH` and `LD_PRELOAD` yield default (empty) such that the access is not flagged by `set -u`

Fixes #835

I don't know if there are similar cases in other shells as I mainly use Bash, so it might need a follow-up for the other init scripts