### PR TITLE
Fix startup failure on luaposix < 36.2

### DIFF
--- a/tools/TermWidth.lua
+++ b/tools/TermWidth.lua
@@ -36,8 +36,8 @@ require("strict")
 
 _G._DEBUG          = false                       -- Required by luaposix 33
 local posix        = require("posix")
-local unistd       = posix.unistd
-local wait         = posix.sys.wait
+local unistd       = require("posix.unistd")
+local wait         = require("posix.sys.wait")
 -- Pull the signal API from the posix.signal submodule.  On the merged `posix`
 -- table `posix.signal` is the signal() *function* (e.g. luaposix 35 on EL9), so
 -- `posix.signal.kill` errors at load time and Lmod fails to start; requiring the


### PR DESCRIPTION
tools/TermWidth.lua read `posix.unistd` and `posix.sys.wait` off the merged top-level `posix` table.  `require("posix")` returns a *flat* table: luaposix's init.lua copies each submodule's keys into it but does not attach the submodule tables themselves.  Attaching them -- rawset(M, name, t) and rawset(M, 'sys', systable) -- was only added in luaposix 36.2, so on 33.x, 34.x, 35.x, 36.0 and 36.1 both values are nil and line 40 raises

    TermWidth.lua:40: attempt to index field 'sys' (a nil value)

at load time.  Lmod then fails to start at all, and `make install` aborts in the man_pages target with a traceback swallowed by the stderr redirect into module.pod.

Require the submodules directly, the same way the neighbouring code already does for posix.signal.  Both have been requirable since luaposix 33, matching the "Required by luaposix 33" note just above.

Regression from the TermWidth rewrite for #832; 9.2.7 was unaffected. Tested on Ubuntu 22.04, Lua 5.2, luaposix 33.4.0.

This fix https://github.com/TACC/Lmod/issues/842