### PR TITLE
Fix numeric handling of cache timing environment variables

### DIFF
--- a/src/Cache.lua
+++ b/src/Cache.lua
@@ -110,7 +110,7 @@ end
 -- @param t A table with possible dontWrite and quiet entries.
 local function l_new(self, t)
    local o       = {}
-   local ancient = cosmic:value("LMOD_ANCIENT_TIME")
+   local ancient = tonumber(cosmic:value("LMOD_ANCIENT_TIME"))
    setmetatable(o,self)
    self.__index = self
 
@@ -441,7 +441,7 @@ local function l_writeUserSpiderCacheWhenNecessary(self, delta_t, mpathA, spider
    local frameStk  = FrameStk:singleton()
    local mt        = frameStk:mt()
    local short     = mt:getShortTime()
-   local threshold = cosmic:value("LMOD_THRESHOLD")
+   local threshold = tonumber(cosmic:value("LMOD_THRESHOLD"))
    local prtRbMsg  = ((not quiet())                        and
                       (not optionTbl.initial)              and
                       ((not short) or (short > shortTime)) and
@@ -578,8 +578,8 @@ end
 function M.build(self, fast)
    fast = fast ~= nil and fast or false
    dbg.start{"Cache:build(fast=", fast,")"}
-   local ancient     = cosmic:value("LMOD_ANCIENT_TIME")
-   local shortTime   = cosmic:value("LMOD_SHORT_TIME")
+   local ancient     = tonumber(cosmic:value("LMOD_ANCIENT_TIME"))
+   local shortTime   = tonumber(cosmic:value("LMOD_SHORT_TIME"))
    local spiderT     = self.spiderT
    local dbT         = self.dbT
    local brokenT     = self.brokenT


### PR DESCRIPTION
## Summary

Convert cache-related values returned by `cosmic:value()` to numbers before using them in arithmetic or numeric comparisons.

When values such as `LMOD_ANCIENT_TIME` are set through environment variables, they may be returned as strings. This causes commands such as `ml avail` and `ml spider` to fail with:

```text
attempt to compare string with number
```

This patch applies `tonumber()` to:

* `LMOD_ANCIENT_TIME`
* `LMOD_SHORT_TIME`
* `LMOD_THRESHOLD`

It also converts `LMOD_ANCIENT_TIME` when initializing the cache object, avoiding reliance on implicit string conversion during arithmetic.

## Reproducer

```bash
export LMOD_ANCIENT_TIME=3600

ml avail
ml spider Python
```

Before this change, both commands can fail in `Cache.build()` when comparing the numeric cache age with the string value of `LMOD_ANCIENT_TIME`.

## Changes

* Convert `LMOD_ANCIENT_TIME` to a number in `l_new()`
* Convert `LMOD_THRESHOLD` to a number in `l_writeUserSpiderCacheWhenNecessary()`
* Convert `LMOD_ANCIENT_TIME` and `LMOD_SHORT_TIME` to numbers in `Cache.build()`

Fixes #846
