### PR TITLE
change the order of suggested commands to give latest version first

### DIFF
--- a/src/MainControl.lua
+++ b/src/MainControl.lua
@@ -754,7 +754,7 @@ local function l_format_dependency_commands(kA, kB, dbT, loadedPathsAA, mt)
       if (a.tokens ~= b.tokens) then return a.tokens < b.tokens end
       if (a.swapCount ~= b.swapCount) then return a.swapCount < b.swapCount end
       if (a.swapDepth ~= b.swapDepth) then return a.swapDepth > b.swapDepth end
-      return a.cmd < b.cmd
+      return a.cmd > b.cmd
    end)
 
    local allCommands = {}


### PR DESCRIPTION
Currently, the suggested commands are in lexicographical order (if swap, tokens, swapCount, and swapDepth are all the same) from least to greatest. This causes modules with older versions to be suggested first, and if there are too many, the latest version will be truncated:
```
Lmod has detected the following error:  These module(s) or extension(s) exist but cannot be loaded as requested:
"git"
   Try: "module spider git" to see how to load the module(s).
   Or load any one of these options:
      module load GCCcore/10.3.0 git
      module load GCCcore/11.2.0 git
      module load GCCcore/11.3.0 git
      module load GCCcore/12.2.0 git
      module load GCCcore/12.3.0 git
      ... and 4 more options
```
This change would cause this list to be reversed, and the latest dependencies at the top instead. Maybe a better change would be to actually take into account dep versions in the sorting of suggested commands.